### PR TITLE
skills/python-native: fix frontmatter to comply with Codex CLI 1024-char limit

### DIFF
--- a/skills/python-native/SKILL.md
+++ b/skills/python-native/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: python-native
-description: >
-  Maximize use of Python's standard library and built-in features before reaching for third-party
-  packages or hand-rolled code. Activate this skill on ANY Python task — writing, reviewing,
-  refactoring, optimizing, or designing. AI assistants routinely reinvent functionality that already
-  exists in `functools`, `itertools`, `collections`, `operator`, `contextlib`, `dataclasses`,
-  `pathlib`, `heapq`, `bisect`, `statistics`, `enum`, `typing`, etc. This skill enforces the rule:
-  *"check the stdlib first"*. It catalogs the under-used built-ins (`singledispatch`, `cache`,
-  `Counter`, `deque`, `chain`, `groupby`, `bisect`, `ExitStack`, `dataclass(slots=True)`, structural
-  pattern matching, `walrus`, `match`/`case`, etc.) and shows when each replaces redundant code.
-  Supports Python 3.9 through 3.14 — version-specific features live in `references/python-3.X.md`.
-  Trigger on any of: "write a Python function", "refactor this Python code", "optimize", "reduce
-  duplication", "implement X in Python", "Pythonic way to…", or whenever Python is mentioned at all.
+description: 'Push Python stdlib idioms over hand-rolled code. Use whenever the user writes, refactors, optimizes, or reviews Python — including one-liners and code-review feedback. Replaces common reinventions: manual dict counters with `Counter`, `dict.setdefault` loops with `defaultdict`, `isinstance` chains with `singledispatch` or `match`/`case`, hand-rolled memoization with `functools.cache`, `os.path.join` with `pathlib.Path`, `sorted(..., reverse=True)[:k]` with `heapq.nlargest`, manual class boilerplate with `dataclass(slots=True, frozen=True)`, `zip(lst, lst[1:])` with `itertools.pairwise`. Covers Python 3.9-3.14 with per-version reference files. Trigger phrases: "write a Python function", "refactor this Python", "Pythonic way to X", "optimize Python code", "make this more Pythonic", "implement X in Python", or any task whose answer involves Python source.'
 ---
 
 # Python Native: Use the Standard Library Before Writing Code


### PR DESCRIPTION
## Summary

Fixes the `python-native` skill frontmatter to comply with the agentskills.io v1.0 standard and the Codex CLI 1024-character hard limit on the `description` field.

## Why this matters

Two real load failures with the current frontmatter:

1. **`description` is 1053 characters** post-YAML-fold (exceeding the 1024-char hard limit). Per agentskills.io v1.0 + Codex CLI: skills with descriptions longer than 1024 chars are silently filtered out before being listed to the model. The skill never reaches the selector.

2. **The frontmatter uses YAML multiline scalar `>`**. Valid YAML, but some runtimes (notably OpenClaw, issue #22134) parse frontmatter line-by-line and silently drop skills that use `>` or `|`. The universally-safe form is single-line single-quoted.

## What changes

Single fix: the description is rewritten from a 1053-char multiline scalar to an 850-char single-line single-quoted string. Content is preserved semantically; the phrasing is more concrete (e.g. "manual dict counters with `Counter`" instead of just listing modules) which also improves the skill selector's confidence in when to load. Trigger phrases that ambiguously caught non-Python tasks (`whenever Python is mentioned at all`) are narrowed to `any task whose answer involves Python source`.

The body of `SKILL.md` and all reference files are **NOT touched** in this PR — they are addressed in a separate PR so they can be reviewed independently.

## Verification

```bash
ruby -ryaml -e "puts YAML.load_file('skills/python-native/SKILL.md')['description'].length"
# Expected: 850 (compliant with ≤1024 hard limit, ≤1000 target)

grep -E '^description: *[>|]' skills/python-native/SKILL.md
# Expected: empty (no multiline scalar)
```

## Authorship

🤖 Generated with [Claude Code](https://claude.com/claude-code)
