### PR TITLE
python-native: correct version-gated stdlib claims (3.12/3.13)

### DIFF
--- a/skills/python-native/SKILL.md
+++ b/skills/python-native/SKILL.md
@@ -604,10 +604,10 @@ f"{dt:%Y-%m-%d}"           # datetime format
 f"{a + b = :,}"            # debug + format spec combined
 ```
 
-Multi-line f-strings (3.12+) allow nested same-quote strings:
+f-strings (3.12+, PEP 701) allow reusing the **same** quote character inside the expression:
 
 ```python
-f"{ ', '.join(f'{x.name!r}' for x in items) }"
+f"{ ", ".join(parts) }"     # outer and inner both double-quoted, SyntaxError before 3.12
 ```
 
 ---

--- a/skills/python-native/references/python-3.12.md
+++ b/skills/python-native/references/python-3.12.md
@@ -91,9 +91,8 @@ groundwork for true parallelism without subprocesses.
 - `calendar.Month`, `calendar.Day` enums.
 - `random.binomialvariate(n, p)` — sample from a binomial distribution.
 - `sys.monitoring` — low-overhead instrumentation hooks (debuggers, coverage) (PEP 669).
-- `array.array` supports `clear()`.
 - Improved `asyncio` performance — eager task factories, faster `gather`.
-- Many small `typing` improvements: `@deprecated`, `Buffer` protocol.
+- Many small `typing` improvements. The `Buffer` protocol (PEP 688) also lands here, but it lives in `collections.abc.Buffer`, not `typing`. (The `@deprecated` decorator, PEP 702, is **not** here; it lands in 3.13 as `warnings.deprecated`.)
 
 ---
 

--- a/skills/python-native/references/python-3.13.md
+++ b/skills/python-native/references/python-3.13.md
@@ -88,7 +88,7 @@ many stdlib types).
 
 - `typing.TypeIs` — a narrower, more accurate cousin of `TypeGuard` for type narrowing.
 - `typing.ReadOnly` for `TypedDict` fields.
-- `warnings.deprecated` (also added in 3.12 as `typing.deprecated`).
+- `warnings.deprecated`: the `@deprecated` decorator (PEP 702). The runtime symbol lives in `warnings`, never `typing`, and is new in 3.13.
 - PEP 696 — type parameter defaults: `class Box[T = int]: ...`.
 
 ---
@@ -111,9 +111,10 @@ Prefer `os.process_cpu_count()` over `os.cpu_count()` for pool sizing in 3.13+.
 ## Other Additions
 
 - `random` module gains a CLI (`python -m random`).
-- `os.path.isreserved` for Windows reserved filenames.
+- `ntpath.isreserved` (and `PureWindowsPath.is_reserved`) for Windows reserved filenames. Exposed as `os.path.isreserved` only on Windows (where `os.path` is `ntpath`); not present on POSIX. `PurePath.is_reserved` was deprecated at the same time.
 - `argparse` deprecation hints, suggestion messages.
 - Better error messages for `NameError`, `AttributeError`, `ImportError` — common typos suggested.
+- `array.array` supports `clear()` (added in 3.13).
 
 ---
 


### PR DESCRIPTION
A small follow-up to the earlier merged python-native PRs.

- `array.array.clear()` is 3.13, not 3.12.
- the `@deprecated` decorator (PEP 702) is `warnings.deprecated`, new in 3.13, and never lived in `typing`.
- `os.path.isreserved` does not exist on POSIX; the real additions are `ntpath.isreserved` and `PureWindowsPath.is_reserved`.
- the `Buffer` protocol lives in `collections.abc`, not `typing`.

I checked each claim on both the 3.12 and 3.13 interpreters.
