### PR TITLE
networkx: fix APIs removed in 3.x, exception handling, and I/O examples (3.6)

### DIFF
--- a/skills/networkx/SKILL.md
+++ b/skills/networkx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: networkx
-description: Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.
+description: 'Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.'
 license: 3-clause BSD license
 metadata:
     skill-author: K-Dense Inc.
@@ -131,7 +131,7 @@ G = nx.watts_strogatz_graph(n=100, k=6, p=0.1, seed=42)
 G = nx.grid_2d_graph(m=5, n=7)
 
 # Random tree
-G = nx.random_tree(n=100, seed=42)
+G = nx.random_labeled_tree(n=100, seed=42)
 ```
 
 **Reference**: See `references/generators.md` for comprehensive coverage of all graph generators including classic, random, lattice, bipartite, and specialized network models with detailed parameters and use cases.
@@ -264,6 +264,12 @@ print(nx.__version__)
 # uv pip install networkx
 # uv pip install networkx[default]  # With optional dependencies
 ```
+
+> **Note**: Examples below that use NumPy, SciPy, pandas, or matplotlib (e.g. matrix
+> conversions, pandas edge lists, and all visualization code) rely on optional
+> dependencies that are not part of base NetworkX. Install them with
+> `uv pip install networkx[default]` (or install the individual packages) before
+> running those snippets.
 
 ### Common Workflow Pattern
 

--- a/skills/networkx/references/algorithms.md
+++ b/skills/networkx/references/algorithms.md
@@ -22,7 +22,7 @@ path = nx.bellman_ford_path(G, source=1, target=5, weight='weight')
 for source, paths in nx.all_pairs_shortest_path(G):
     print(f"From {source}: {paths}")
 
-# Floyd-Warshall algorithm
+# All pairs shortest path lengths
 lengths = dict(nx.all_pairs_shortest_path_length(G))
 ```
 
@@ -112,8 +112,9 @@ approx_betweenness = nx.betweenness_centrality(G, k=100)  # Sample 100 nodes
 # Reciprocal of average shortest path length
 closeness = nx.closeness_centrality(G)
 
-# For disconnected graphs
-closeness = nx.closeness_centrality(G, wf_improved=True)
+# wf_improved=True (the default) scales by reachable fraction for disconnected graphs;
+# pass wf_improved=False to disable the Wasserman-Faust correction
+closeness = nx.closeness_centrality(G, wf_improved=False)
 ```
 
 ### Eigenvector Centrality
@@ -224,7 +225,7 @@ mst = nx.minimum_spanning_tree(G, weight='weight')
 mst_max = nx.maximum_spanning_tree(G, weight='weight')
 
 # Enumerate all spanning trees
-all_spanning = nx.all_spanning_trees(G)
+all_spanning = nx.SpanningTreeIterator(G)
 ```
 
 ### Tree Properties
@@ -241,14 +242,14 @@ is_arborescence = nx.is_arborescence(G)
 
 ### Maximum Flow
 ```python
-# Maximum flow value
-flow_value = nx.maximum_flow_value(G, s=1, t=5, capacity='capacity')
+# Maximum flow value (source and sink are positional arguments)
+flow_value = nx.maximum_flow_value(G, 1, 5, capacity='capacity')
 
 # Maximum flow with flow dict
-flow_value, flow_dict = nx.maximum_flow(G, s=1, t=5, capacity='capacity')
+flow_value, flow_dict = nx.maximum_flow(G, 1, 5, capacity='capacity')
 
 # Minimum cut
-cut_value, partition = nx.minimum_cut(G, s=1, t=5, capacity='capacity')
+cut_value, partition = nx.minimum_cut(G, 1, 5, capacity='capacity')
 ```
 
 ### Cost Flow
@@ -277,7 +278,7 @@ is_dag = nx.is_directed_acyclic_graph(G)
 # Only for DAGs
 try:
     topo_order = list(nx.topological_sort(G))
-except nx.NetworkXError:
+except nx.NetworkXUnfeasible:
     print("Graph has cycles")
 
 # All topological sorts
@@ -294,8 +295,8 @@ cliques = list(nx.find_cliques(G))
 # Maximum clique (NP-complete, approximate)
 max_clique = nx.approximation.max_clique(G)
 
-# Clique number
-clique_number = nx.graph_clique_number(G)
+# Clique number (graph_clique_number was removed; derive from find_cliques)
+clique_number = max(len(c) for c in nx.find_cliques(G))
 
 # Number of maximal cliques containing each node
 clique_counts = nx.node_clique_number(G)

--- a/skills/networkx/references/generators.md
+++ b/skills/networkx/references/generators.md
@@ -117,7 +117,7 @@ G = nx.random_powerlaw_tree(n=100, gamma=3, seed=42, tries=1000)
 ### Configuration Model
 ```python
 # Graph with specified degree sequence
-degree_sequence = [3, 3, 3, 3, 2, 2, 2, 1, 1, 1]
+degree_sequence = [3, 3, 3, 3, 2, 2, 2, 2, 1, 1]
 G = nx.configuration_model(degree_sequence, seed=42)
 
 # Remove self-loops and parallel edges
@@ -178,7 +178,7 @@ G = nx.hypercube_graph(n=4)
 ### Random Trees
 ```python
 # Random tree with n nodes
-G = nx.random_tree(n=100, seed=42)
+G = nx.random_labeled_tree(n=100, seed=42)
 
 # Prefix tree (tries)
 G = nx.prefix_tree([[0, 1, 2], [0, 1, 3], [0, 4]])
@@ -249,7 +249,7 @@ G = nx.DiGraph([(u, v) for (u, v) in G.edges() if u < v])  # Remove backward edg
 ### Tournament Graphs
 ```python
 # Random tournament (complete directed graph)
-G = nx.random_tournament(n=10, seed=42)
+G = nx.tournament.random_tournament(n=10, seed=42)
 ```
 
 ## Duplication-Divergence Models
@@ -265,7 +265,7 @@ G = nx.duplication_divergence_graph(n=100, p=0.5, seed=42)
 ### Valid Degree Sequences
 ```python
 # Check if degree sequence is valid (graphical)
-sequence = [3, 3, 3, 3, 2, 2, 2, 1, 1, 1]
+sequence = [3, 3, 3, 3, 2, 2, 2, 2, 1, 1]
 is_valid = nx.is_graphical(sequence)
 
 # For directed graphs
@@ -294,7 +294,7 @@ G = nx.directed_configuration_model(in_degree_sequence, out_degree_sequence)
 G = nx.bipartite.random_graph(n=50, m=30, p=0.1, seed=42)
 
 # Configuration model for bipartite
-G = nx.bipartite.configuration_model(deg1=[3, 3, 2], deg2=[2, 2, 2, 2], seed=42)
+G = nx.bipartite.configuration_model(aseq=[3, 3, 2], bseq=[2, 2, 2, 2], seed=42)
 ```
 
 ### Bipartite Generators

--- a/skills/networkx/references/graph-basics.md
+++ b/skills/networkx/references/graph-basics.md
@@ -245,7 +245,8 @@ G_directed = G.to_directed()
 
 ### Basic Information
 ```python
-print(nx.info(G))   # Summary of graph structure
+# nx.info was removed in NetworkX 3.0; use direct attributes instead
+print(G.number_of_nodes(), "nodes,", G.number_of_edges(), "edges")
 
 # Density (ratio of actual edges to possible edges)
 nx.density(G)

--- a/skills/networkx/references/io.md
+++ b/skills/networkx/references/io.md
@@ -108,8 +108,8 @@ nx.write_pajek(G, 'graph.net')
 # Read LEDA format
 G = nx.read_leda('graph.leda')
 
-# Write LEDA format
-nx.write_leda(G, 'graph.leda')
+# Writing LEDA is not supported by NetworkX (nx.write_leda does not exist);
+# only nx.read_leda is available for the LEDA format.
 ```
 
 ## Working with Pandas
@@ -206,14 +206,15 @@ G = nx.from_scipy_sparse_array(A)
 import json
 
 # To node-link format (good for d3.js)
-data = nx.node_link_data(G)
+# The edges= parameter was added in NetworkX 3.4; the default key became "edges" in 3.6 (was "links"). Passing it is optional.
+data = nx.node_link_data(G, edges="edges")
 with open('graph.json', 'w') as f:
     json.dump(data, f)
 
 # From node-link format
 with open('graph.json', 'r') as f:
     data = json.load(f)
-G = nx.node_link_graph(data)
+G = nx.node_link_graph(data, edges="edges")
 ```
 
 ### Adjacency Data Format
@@ -231,8 +232,10 @@ G = nx.adjacency_graph(data)
 
 ### Tree Data Format
 ```python
-# For tree graphs
-data = nx.tree_data(G, root=0)
+# For tree graphs; tree_data requires a directed, rooted tree
+# convert an undirected tree with nx.bfs_tree(G, root) first
+DG = nx.bfs_tree(G, 0)
+data = nx.tree_data(DG, root=0)
 with open('tree.json', 'w') as f:
     json.dump(data, f)
 
@@ -256,9 +259,11 @@ with open('graph.pkl', 'wb') as f:
 with open('graph.pkl', 'rb') as f:
     G = pickle.load(f)
 
-# NetworkX convenience functions
-nx.write_gpickle(G, 'graph.gpickle')
-G = nx.read_gpickle('graph.gpickle')
+# Use stdlib pickle (write_gpickle/read_gpickle were removed in NetworkX 3.0)
+with open('graph.gpickle', 'wb') as f:
+    pickle.dump(G, f)
+with open('graph.gpickle', 'rb') as f:
+    G = pickle.load(f)
 ```
 
 ## CSV Files
@@ -350,12 +355,9 @@ mmwrite('graph.mtx', A)
 
 ### Shapefile (for Geographic Networks)
 ```python
-# Requires pyshp library
-# Read geographic network from shapefile
-G = nx.read_shp('roads.shp')
-
-# Write to shapefile
-nx.write_shp(G, 'network')
+# nx.read_shp / nx.write_shp were removed in NetworkX 3.0 and have no built-in
+# replacement. Use an external library (e.g. geopandas/fiona/pyshp) to read the
+# shapefile, then build the graph from the resulting geometries.
 ```
 
 ## Format Selection Guidelines
@@ -392,15 +394,18 @@ nx.write_shp(G, 'network')
 For large graphs, consider:
 ```python
 # Use compressed formats
+# write_adjlist/read_adjlist operate on bytes, so open gzip in binary mode
 import gzip
-with gzip.open('graph.adjlist.gz', 'wt') as f:
+with gzip.open('graph.adjlist.gz', 'wb') as f:
     nx.write_adjlist(G, f)
 
-with gzip.open('graph.adjlist.gz', 'rt') as f:
+with gzip.open('graph.adjlist.gz', 'rb') as f:
     G = nx.read_adjlist(f)
 
-# Use binary formats (faster)
-nx.write_gpickle(G, 'graph.gpickle')  # Faster than text formats
+# Use binary formats (faster); write_gpickle was removed in NetworkX 3.0, use stdlib pickle
+import pickle
+with open('graph.gpickle', 'wb') as f:
+    pickle.dump(G, f)  # Faster than text formats
 
 # Use sparse matrices for adjacency
 A = nx.to_scipy_sparse_array(G, format='csr')  # Memory efficient

--- a/skills/networkx/references/visualization.md
+++ b/skills/networkx/references/visualization.md
@@ -119,7 +119,11 @@ nx.draw(G, node_color=node_colors)
 # Color by attribute
 colors = [G.nodes[n].get('value', 0) for n in G.nodes()]
 nx.draw(G, node_color=colors, cmap=plt.cm.viridis)
-plt.colorbar()
+# nx.draw returns None, so colorbar needs an explicit ScalarMappable
+sm = plt.cm.ScalarMappable(cmap=plt.cm.viridis,
+                           norm=plt.Normalize(vmin=min(colors), vmax=max(colors)))
+sm.set_array(colors)
+plt.colorbar(sm, ax=plt.gca())
 plt.show()
 ```
 


### PR DESCRIPTION
- replace functions removed in networkx 3.x with their current equivalents.
- catch `NetworkXUnfeasible` (not `NetworkXError`) after `topological_sort` on a cyclic graph.
- build a `ScalarMappable` before `plt.colorbar()` after `nx.draw`, which returns None.
- open gzip in binary mode for `write_adjlist`/`read_adjlist`, and pass a directed rooted tree to `tree_data`.

Each snippet runs clean on networkx 3.6.1.
