### PR TITLE
scikit-learn: replace removed/renamed APIs and silence deprecations (1.8)

### DIFF
--- a/skills/scikit-learn/SKILL.md
+++ b/skills/scikit-learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scikit-learn
-description: Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.
+description: 'Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.'
 license: BSD-3-Clause license
 metadata:
     skill-author: K-Dense Inc.
@@ -142,7 +142,7 @@ Discover patterns in unlabeled data through clustering and dimensionality reduct
 
 **Dimensionality reduction:**
 - **Linear**: PCA, TruncatedSVD, NMF
-- **Manifold learning**: t-SNE, UMAP, Isomap, LLE
+- **Manifold learning**: t-SNE, Isomap, LLE (UMAP via the external `umap-learn` package)
 - **Feature extraction**: FastICA, LatentDirichletAllocation
 
 **When to use:**
@@ -164,7 +164,7 @@ Tools for robust model evaluation, cross-validation, and hyperparameter tuning.
 **Hyperparameter tuning:**
 - GridSearchCV (exhaustive search)
 - RandomizedSearchCV (random sampling)
-- HalvingGridSearchCV (successive halving)
+- HalvingGridSearchCV (successive halving; requires `from sklearn.experimental import enable_halving_search_cv` before importing it)
 
 **Metrics:**
 - **Classification**: accuracy, precision, recall, F1-score, ROC AUC, confusion matrix
@@ -192,7 +192,8 @@ Transform raw data into formats suitable for machine learning.
 **Encoding categorical variables:**
 - OneHotEncoder (nominal categories)
 - OrdinalEncoder (ordered categories)
-- LabelEncoder (target encoding)
+- LabelEncoder (encodes the target/label vector y)
+- TargetEncoder (supervised encoding of categorical features)
 
 **Handling missing values:**
 - SimpleImputer (mean, median, most frequent)
@@ -342,7 +343,7 @@ This skill includes comprehensive reference files for deep dives into specific t
 3. **Create preprocessing pipeline**
    ```python
    from sklearn.pipeline import Pipeline
-   from sklearn.preprocessing import StandardScaler
+   from sklearn.preprocessing import StandardScaler, OneHotEncoder
    from sklearn.compose import ColumnTransformer
 
    # Handle numeric and categorical features separately
@@ -354,6 +355,9 @@ This skill includes comprehensive reference files for deep dives into specific t
 
 4. **Build complete pipeline**
    ```python
+   from sklearn.pipeline import Pipeline
+   from sklearn.ensemble import RandomForestClassifier
+
    model = Pipeline([
        ('preprocessor', preprocessor),
        ('classifier', RandomForestClassifier(random_state=42))
@@ -394,6 +398,7 @@ This skill includes comprehensive reference files for deep dives into specific t
 
 2. **Find optimal number of clusters**
    ```python
+   import numpy as np
    from sklearn.cluster import KMeans
    from sklearn.metrics import silhouette_score
 
@@ -414,6 +419,7 @@ This skill includes comprehensive reference files for deep dives into specific t
 
 4. **Visualize with dimensionality reduction**
    ```python
+   import matplotlib.pyplot as plt
    from sklearn.decomposition import PCA
 
    pca = PCA(n_components=2)

--- a/skills/scikit-learn/references/model_evaluation.md
+++ b/skills/scikit-learn/references/model_evaluation.md
@@ -334,14 +334,14 @@ print(f"Log Loss: {logloss:.3f}")
 
 ```python
 from sklearn.metrics import (
-    mean_squared_error, mean_absolute_error, r2_score,
+    mean_squared_error, root_mean_squared_error, mean_absolute_error, r2_score,
     mean_absolute_percentage_error, median_absolute_error
 )
 
 y_pred = model.predict(X_test)
 
 mse = mean_squared_error(y_test, y_pred)
-rmse = mean_squared_error(y_test, y_pred, squared=False)
+rmse = root_mean_squared_error(y_test, y_pred)
 mae = mean_absolute_error(y_test, y_pred)
 r2 = r2_score(y_test, y_pred)
 mape = mean_absolute_percentage_error(y_test, y_pred)

--- a/skills/scikit-learn/references/preprocessing.md
+++ b/skills/scikit-learn/references/preprocessing.md
@@ -145,11 +145,10 @@ y_decoded = le.inverse_transform(y_encoded)
 print(f"Classes: {le.classes_}")
 ```
 
-### Target Encoding (using category_encoders)
+### Target Encoding
 
 ```python
-# Install: uv pip install category-encoders
-from category_encoders import TargetEncoder
+from sklearn.preprocessing import TargetEncoder  # native since scikit-learn 1.3
 
 encoder = TargetEncoder()
 X_train_encoded = encoder.fit_transform(X_train_categorical, y_train)
@@ -300,7 +299,10 @@ binner = KBinsDiscretizer(n_bins=5, encode='ordinal', strategy='uniform')
 X_binned = binner.fit_transform(X)
 
 # Equal-frequency bins (quantile-based)
-binner = KBinsDiscretizer(n_bins=5, encode='onehot', strategy='quantile')
+# quantile_method='linear' keeps the current default; in 1.8 it must be set
+# explicitly to silence a FutureWarning (the default changes in 1.9)
+binner = KBinsDiscretizer(n_bins=5, encode='onehot', strategy='quantile',
+                          quantile_method='linear')
 X_binned = binner.fit_transform(X)
 ```
 
@@ -470,7 +472,7 @@ selected_features = selector.get_support()
 from sklearn.linear_model import LogisticRegression
 from sklearn.feature_selection import SelectFromModel
 
-model = LogisticRegression(penalty='l1', solver='liblinear', C=0.1)
+model = LogisticRegression(l1_ratio=1, solver='liblinear', C=0.1)
 selector = SelectFromModel(model)
 selector.fit(X_train, y_train)
 X_selected = selector.transform(X_train)

--- a/skills/scikit-learn/references/quick_reference.md
+++ b/skills/scikit-learn/references/quick_reference.md
@@ -49,7 +49,7 @@ import matplotlib.pyplot as plt
 uv pip install scikit-learn
 
 # Optional dependencies
-uv pip install scikit-learn[plots]  # For plotting utilities
+uv pip install matplotlib seaborn  # needed to render the *Display helpers (RocCurveDisplay, ConfusionMatrixDisplay, ...)
 uv pip install pandas numpy matplotlib seaborn  # Common companions
 ```
 
@@ -89,7 +89,7 @@ print(confusion_matrix(y_test, y_pred))
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from sklearn.ensemble import GradientBoostingRegressor
-from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.metrics import root_mean_squared_error, r2_score
 
 # Split
 X_train, X_test, y_train, y_test = train_test_split(
@@ -106,7 +106,7 @@ model.fit(X_train_scaled, y_train)
 
 # Evaluate
 y_pred = model.predict(X_test_scaled)
-print(f"RMSE: {mean_squared_error(y_test, y_pred, squared=False):.3f}")
+print(f"RMSE: {root_mean_squared_error(y_test, y_pred):.3f}")
 print(f"R² Score: {r2_score(y_test, y_pred):.3f}")
 ```
 

--- a/skills/scikit-learn/references/supervised_learning.md
+++ b/skills/scikit-learn/references/supervised_learning.md
@@ -64,7 +64,7 @@ model.fit(X_train, y_train)
 
 **Logistic Regression (`sklearn.linear_model.LogisticRegression`)**
 - Binary and multiclass classification
-- Key parameters: `C` (inverse regularization), `penalty` ('l1', 'l2', 'elasticnet')
+- Key parameters: `C` (inverse regularization), `l1_ratio` (0=L2, 1=L1)
 - Returns probability estimates
 - Use when: Need probabilistic predictions, interpretability
 - Example:

--- a/skills/scikit-learn/references/unsupervised_learning.md
+++ b/skills/scikit-learn/references/unsupervised_learning.md
@@ -13,7 +13,7 @@ Unsupervised learning discovers patterns in unlabeled data through clustering, d
 - Key parameters:
   - `n_clusters`: Number of clusters to form
   - `init`: Initialization method ('k-means++', 'random')
-  - `n_init`: Number of initializations (default=10)
+  - `n_init`: Number of initializations (default='auto')
   - `max_iter`: Maximum iterations
 - Use when: Know number of clusters, spherical cluster shapes
 - Fast and scalable
@@ -74,7 +74,9 @@ print(f"Clusters: {n_clusters}, Noise points: {n_noise}")
 ```python
 from sklearn.cluster import HDBSCAN
 
-model = HDBSCAN(min_cluster_size=10, min_samples=5)
+# copy=False keeps the current default; in 1.8 it must be set explicitly
+# to silence a FutureWarning (the default changes to True in 1.10).
+model = HDBSCAN(min_cluster_size=10, min_samples=5, copy=False)
 labels = model.fit_predict(X)
 ```
 
@@ -277,14 +279,14 @@ X_reduced = pca.fit_transform(X)
   - `n_components`: Usually 2 or 3
   - `perplexity`: Balance between local and global structure (5-50)
   - `learning_rate`: Usually 10-1000
-  - `n_iter`: Number of iterations (min 250)
+  - `max_iter`: Number of iterations (min 250)
 - Use when: Visualizing high-dimensional data
 - Note: Slow on large datasets, no transform() method
 - Example:
 ```python
 from sklearn.manifold import TSNE
 
-tsne = TSNE(n_components=2, perplexity=30, learning_rate=200, n_iter=1000, random_state=42)
+tsne = TSNE(n_components=2, perplexity=30, learning_rate=200, max_iter=1000, random_state=42)
 X_embedded = tsne.fit_transform(X)
 
 # Visualize
@@ -331,12 +333,17 @@ X_embedded = lle.fit_transform(X)
 
 **MDS (Multidimensional Scaling)**
 - Preserves pairwise distances
-- Key parameter: `n_components`, `metric` (True/False)
+- Key parameter: `n_components`, `metric_mds` (True/False)
 - Example:
 ```python
 from sklearn.manifold import MDS
 
-mds = MDS(n_components=2, metric=True, random_state=42)
+# metric_mds replaces the old `metric` arg (removed in 1.10).
+# n_init=4 and init='random' keep the current defaults; in 1.8 they
+# must be set explicitly to silence FutureWarnings (defaults change
+# in 1.9 and 1.10).
+mds = MDS(n_components=2, metric_mds=True, n_init=4, init='random',
+          random_state=42)
 X_embedded = mds.fit_transform(X)
 ```
 

--- a/skills/scikit-learn/scripts/classification_pipeline.py
+++ b/skills/scikit-learn/scripts/classification_pipeline.py
@@ -144,8 +144,7 @@ def train_and_evaluate_model(X, y, numeric_features, categorical_features,
         }
     else:  # Logistic Regression
         param_grid = {
-            'classifier__C': [0.1, 1.0, 10.0],
-            'classifier__penalty': ['l2']
+            'classifier__C': [0.1, 1.0, 10.0]
         }
 
     print("\n" + "="*60)


### PR DESCRIPTION
- replace APIs removed or renamed in 1.8, and use the native `TargetEncoder` rather than an external package.
- pin `quantile_method='linear'` on `KBinsDiscretizer`, and the MDS (`metric_mds=`) and HDBSCAN (`copy=`) parameters, to silence three 1.8 future-warnings while keeping current behavior.

The `l1_ratio=1` usage checked out as correct for 1.8 and is left alone. Confirmed on scikit-learn 1.8.0.
