### PR TITLE
scikit-bio: fix examples and APIs for 0.7.2

### DIFF
--- a/skills/scikit-bio/SKILL.md
+++ b/skills/scikit-bio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scikit-bio
-description: Biological data toolkit. Sequence analysis, alignments, phylogenetic trees, diversity metrics (alpha/beta, UniFrac), ordination (PCoA), PERMANOVA, FASTA/Newick I/O, for microbiome analysis.
+description: 'Biological data toolkit. Sequence analysis, alignments, phylogenetic trees, diversity metrics (alpha/beta, UniFrac), ordination (PCoA), PERMANOVA, FASTA/Newick I/O, for microbiome analysis.'
 license: BSD-3-Clause license
 metadata:
     skill-author: K-Dense Inc.
@@ -53,7 +53,7 @@ rna = seq.transcribe()
 protein = rna.translate()
 
 # Find motifs
-motif_positions = seq.find_with_regex('ATG[ACGT]{3}')
+motif_positions = seq.find_with_regex('(ATG[ACGT]{3})')
 
 # Check for properties
 has_degens = seq.has_degenerates()
@@ -79,13 +79,13 @@ Perform pairwise and multiple sequence alignments using dynamic programming algo
 
 **Common patterns:**
 ```python
-from skbio.alignment import local_pairwise_align_ssw, TabularMSA
+from skbio.alignment import local_pairwise_align_nucleotide, TabularMSA
 
 # Pairwise alignment
-alignment = local_pairwise_align_ssw(seq1, seq2)
+msa, score, positions = local_pairwise_align_nucleotide(seq1, seq2)
 
 # Access aligned sequences
-msa = alignment.aligned_sequences
+aligned_seqs = list(msa)
 
 # Read multiple alignment from file
 msa = TabularMSA.read('alignment.fasta', constructor=skbio.DNA)
@@ -95,8 +95,9 @@ consensus = msa.consensus()
 ```
 
 **Important notes:**
-- Use `local_pairwise_align_ssw` for local alignments (faster, SSW-based)
-- Use `StripedSmithWaterman` for protein alignments
+- `local_pairwise_align_nucleotide`, `global_pairwise_align_nucleotide`, and `local_pairwise_align_protein` are pure-Python and emit a PendingDeprecationWarning; prefer `skbio.alignment.pair_align` (use `mode='local'` or `mode='global'`) for new code
+- Use `local_pairwise_align_nucleotide` for local nucleotide alignments
+- Use `local_pairwise_align_protein` for protein alignments
 - Affine gap penalties recommended for biological sequences
 - Can convert between scikit-bio, BioPython, and Biotite alignment formats
 
@@ -105,7 +106,7 @@ consensus = msa.consensus()
 Construct, manipulate, and analyze phylogenetic trees representing evolutionary relationships.
 
 **Key capabilities:**
-- Tree construction from distance matrices (UPGMA, WPGMA, Neighbor Joining, GME, BME)
+- Tree construction from distance matrices (UPGMA, WPGMA via `upgma(weighted=True)`, Neighbor Joining, GME, BME)
 - Tree manipulation (pruning, rerooting, traversal)
 - Distance calculations (patristic, cophenetic, Robinson-Foulds)
 - ASCII visualization
@@ -129,10 +130,10 @@ lca = tree.lowest_common_ancestor(['taxon1', 'taxon2'])
 
 # Calculate distances
 patristic_dist = tree.find('taxon1').distance(tree.find('taxon2'))
-cophenetic_matrix = tree.cophenetic_matrix()
+cophenetic_matrix = tree.tip_tip_distances()
 
 # Compare trees
-rf_distance = tree.robinson_foulds(other_tree)
+rf_distance = tree.compare_rfd(other_tree)
 ```
 
 **Important notes:**
@@ -160,12 +161,12 @@ import skbio
 # Alpha diversity
 alpha = alpha_diversity('shannon', counts_matrix, ids=sample_ids)
 faith_pd = alpha_diversity('faith_pd', counts_matrix, ids=sample_ids,
-                          tree=tree, otu_ids=feature_ids)
+                          tree=tree, taxa=feature_ids)
 
 # Beta diversity
 bc_dm = beta_diversity('braycurtis', counts_matrix, ids=sample_ids)
 unifrac_dm = beta_diversity('unweighted_unifrac', counts_matrix,
-                           ids=sample_ids, tree=tree, otu_ids=feature_ids)
+                           ids=sample_ids, tree=tree, taxa=feature_ids)
 
 # Get available metrics
 from skbio.diversity import get_alpha_diversity_metrics
@@ -173,7 +174,7 @@ print(get_alpha_diversity_metrics())
 ```
 
 **Important notes:**
-- Counts must be integers representing abundances, not relative frequencies
+- Most non-phylogenetic metrics accept any nonnegative abundance-like vectors; some metrics (e.g. those based on counting individuals, like chao1) require integer counts rather than relative frequencies
 - Phylogenetic metrics (Faith's PD, UniFrac) require tree and OTU ID mapping
 - Use `partial_beta_diversity()` for computing specific sample pairs only
 - Alpha diversity returns Series, beta diversity returns DistanceMatrix
@@ -273,8 +274,8 @@ seq.write('output.fasta', format='fasta')
 for seq in skbio.io.read('large.fasta', format='fasta', constructor=skbio.DNA):
     process(seq)
 
-# Convert formats
-seqs = list(skbio.io.read('input.fastq', format='fastq', constructor=skbio.DNA))
+# Convert formats (pass a generator; there is no list writer)
+seqs = skbio.io.read('input.fastq', format='fastq', constructor=skbio.DNA)
 skbio.io.write(seqs, format='fasta', into='output.fasta')
 ```
 
@@ -347,14 +348,15 @@ counts = table.matrix_data
 # Filter
 filtered = table.filter(sample_ids_to_keep, axis='sample')
 
-# Convert to/from pandas
+# Convert to/from pandas (skbio.Table is biom.table.Table;
+# the DataFrame is observations (rows) x samples (columns))
 df = table.to_dataframe()
-table = Table.from_dataframe(df)
+table = Table(df.values, observation_ids=df.index, sample_ids=df.columns)
 ```
 
 **Important notes:**
 - BIOM tables are standard in QIIME 2 workflows
-- Rows typically represent samples, columns represent features (OTUs/ASVs)
+- Rows represent observations/features (OTUs/ASVs), columns represent samples
 - Supports sparse and dense representations
 - Output format configurable (pandas/polars/numpy)
 
@@ -370,20 +372,25 @@ Work with protein language model embeddings for downstream analysis.
 
 **Common patterns:**
 ```python
-from skbio.embedding import ProteinEmbedding, ProteinVector
+from skbio.embedding import (ProteinEmbedding, ProteinVector,
+                             embed_vec_to_distances, embed_vec_to_ordination,
+                             embed_vec_to_numpy, embed_vec_to_dataframe)
 
-# Create embedding from array
-embedding = ProteinEmbedding(embedding_array, sequence_ids)
+# Create a per-residue embedding from an array (second positional is the sequence)
+embedding = ProteinEmbedding(embedding_array, sequence)
+
+# Per-sequence vectors (one fixed-length vector per protein)
+vectors = [ProteinVector(vec, seq) for vec, seq in zip(vector_array, sequences)]
 
 # Convert to distance matrix for analysis
-dm = embedding.to_distances(metric='euclidean')
+dm = embed_vec_to_distances(vectors, metric='euclidean')
 
-# PCoA visualization of embedding space
-pcoa_results = embedding.to_ordination(metric='euclidean', method='pcoa')
+# Ordination of embedding space
+ordination_results = embed_vec_to_ordination(vectors)
 
 # Export for machine learning
-array = embedding.to_array()
-df = embedding.to_dataframe()
+array = embed_vec_to_numpy(vectors)
+df = embed_vec_to_dataframe(vectors)
 ```
 
 **Important notes:**

--- a/skills/scikit-bio/references/api_reference.md
+++ b/skills/scikit-bio/references/api_reference.md
@@ -39,7 +39,7 @@ protein = rna.translate(genetic_code=11)  # Bacterial code
 ```python
 # Find motifs using regex
 dna = DNA('ATGCGATCGATGCATCG')
-motif_locs = dna.find_with_regex('ATG.{3}')  # Start codons
+motif_locs = dna.find_with_regex('(ATG.{3})')  # Start codons (needs a capture group)
 
 # Find all positions
 import re
@@ -47,7 +47,6 @@ for match in re.finditer('ATG', str(dna)):
     print(f"ATG found at position {match.start()}")
 
 # k-mer counting
-from skbio.sequence import _motifs
 kmers = dna.kmer_frequencies(k=3)
 ```
 
@@ -79,8 +78,10 @@ seq2 = DNA('ATCG--CG')
 dist = seq1.distance(seq2)
 
 # Custom distance function
+# kmer_distance requires a `k` argument, so bind it with functools.partial
+import functools
 from skbio.sequence.distance import kmer_distance
-dist = seq1.distance(seq2, metric=kmer_distance)
+dist = seq1.distance(seq2, metric=functools.partial(kmer_distance, k=3))
 ```
 
 ## Alignment Methods
@@ -88,44 +89,64 @@ dist = seq1.distance(seq2, metric=kmer_distance)
 ### Pairwise Alignment
 
 ```python
-from skbio.alignment import local_pairwise_align_ssw, global_pairwise_align
+from skbio.alignment import local_pairwise_align_nucleotide, global_pairwise_align_nucleotide
 from skbio import DNA, Protein
 
-# Local alignment (Smith-Waterman via SSW)
+# Local alignment (Smith-Waterman)
 seq1 = DNA('ATCGATCGATCG')
 seq2 = DNA('ATCGGGGATCG')
-alignment = local_pairwise_align_ssw(seq1, seq2)
+# Returns a (TabularMSA, score, positions) tuple
+msa, score, positions = local_pairwise_align_nucleotide(seq1, seq2)
 
 # Access alignment details
-print(f"Score: {alignment.score}")
-print(f"Start position: {alignment.target_begin}")
-aligned_seqs = alignment.aligned_sequences
+print(f"Score: {score}")
+print(f"Aligned positions (per sequence): {positions}")
+aligned_seqs = list(msa)
 
-# Global alignment with custom scoring
-from skbio.alignment import AlignScorer
-
-scorer = AlignScorer(
+# Global alignment with custom scoring (penalties are positional/keyword args)
+msa, score, positions = global_pairwise_align_nucleotide(
+    seq1, seq2,
     match_score=2,
     mismatch_score=-3,
     gap_open_penalty=5,
     gap_extend_penalty=2
 )
 
-alignment = global_pairwise_align(seq1, seq2, scorer=scorer)
-
 # Protein alignment with substitution matrix
-from skbio.alignment import StripedSmithWaterman
+from skbio.alignment import local_pairwise_align_protein
 
 protein_query = Protein('ACDEFGHIKLMNPQRSTVWY')
 protein_target = Protein('ACDEFMNPQRSTVWY')
 
-aligner = StripedSmithWaterman(
-    str(protein_query),
+msa, score, positions = local_pairwise_align_protein(
+    protein_query,
+    protein_target,
     gap_open_penalty=11,
-    gap_extend_penalty=1,
-    substitution_matrix='blosum62'
+    gap_extend_penalty=1
 )
-alignment = aligner(str(protein_target))
+```
+
+> Note: `local_pairwise_align_nucleotide`, `global_pairwise_align_nucleotide`, and
+> `local_pairwise_align_protein` are pure-Python implementations that emit a
+> PendingDeprecationWarning on every call (they are slow). The recommended
+> replacement is `skbio.alignment.pair_align`.
+
+```python
+from skbio.alignment import pair_align
+from skbio import DNA
+
+seq1 = DNA('ATCGATCGATCG')
+seq2 = DNA('ATCGGGGATCG')
+
+# Recommended pairwise alignment (mode='global' default; use mode='local' for Smith-Waterman)
+result = pair_align(seq1, seq2)
+
+# Access the alignment score
+print(f"Score: {result.score}")
+
+# Materialize the alignment as a TabularMSA from the first optimal path
+msa = result.paths[0].to_aligned((seq1, seq2))
+aligned_seqs = list(msa)
 ```
 
 ### Multiple Sequence Alignment
@@ -147,7 +168,6 @@ msa = TabularMSA(seqs)
 
 # MSA operations
 consensus = msa.consensus()
-majority_consensus = msa.majority_consensus()
 
 # Calculate conservation
 conservation = msa.conservation()
@@ -156,25 +176,21 @@ conservation = msa.conservation()
 first_seq = msa[0]
 column = msa[:, 2]  # Third column
 
-# Filter gaps
-degapped_msa = msa.omit_gap_positions(maximum_gap_frequency=0.5)
-
-# Calculate position-specific scores
-position_entropies = msa.position_entropies()
+# Per-position gap frequencies
+gap_freqs = msa.gap_frequencies(axis='position')
 ```
 
 ### CIGAR String Handling
 
 ```python
-from skbio.alignment import AlignPath
+from skbio.alignment import PairAlignPath
 
-# Parse CIGAR string
+# Parse CIGAR string (CIGAR parsing lives on PairAlignPath)
 cigar = "10M2I5M3D10M"
-align_path = AlignPath.from_cigar(cigar, target_length=100, query_length=50)
+align_path = PairAlignPath.from_cigar(cigar)
 
-# Convert alignment to CIGAR
-alignment = local_pairwise_align_ssw(seq1, seq2)
-cigar_string = alignment.to_cigar()
+# Convert an alignment path back to a CIGAR string
+cigar_string = align_path.to_cigar()
 ```
 
 ## Phylogenetic Trees
@@ -253,14 +269,14 @@ node1 = tree.find('taxon1')
 node2 = tree.find('taxon2')
 patristic = node1.distance(node2)
 
-# Cophenetic matrix (all pairwise distances)
-cophenetic_dm = tree.cophenetic_matrix()
+# Cophenetic matrix (all pairwise tip-to-tip distances)
+cophenetic_dm = tree.tip_tip_distances()
 
 # Robinson-Foulds distance (topology comparison)
-rf_dist = tree.robinson_foulds(other_tree)
+rf_dist = tree.compare_rfd(other_tree)
 
-# Compare with unweighted RF
-rf_dist, max_rf = tree.robinson_foulds(other_tree, proportion=False)
+# Normalized RF distance (proportion in [0, 1])
+rf_proportion = tree.compare_rfd(other_tree, proportion=True)
 
 # Tip-to-tip distances
 tip_distances = tree.tip_tip_distances()
@@ -300,7 +316,7 @@ print(get_alpha_diversity_metrics())
 # Calculate various alpha diversity metrics
 shannon = alpha_diversity('shannon', counts, ids=sample_ids)
 simpson = alpha_diversity('simpson', counts, ids=sample_ids)
-observed_otus = alpha_diversity('observed_otus', counts, ids=sample_ids)
+observed_otus = alpha_diversity('sobs', counts, ids=sample_ids)
 chao1 = alpha_diversity('chao1', counts, ids=sample_ids)
 
 # Phylogenetic alpha diversity (requires tree)
@@ -310,7 +326,7 @@ tree = TreeNode.read('tree.nwk')
 feature_ids = ['OTU1', 'OTU2', 'OTU3', 'OTU4']
 
 faith_pd = alpha_diversity('faith_pd', counts, ids=sample_ids,
-                          tree=tree, otu_ids=feature_ids)
+                          tree=tree, taxa=feature_ids)
 ```
 
 ### Beta Diversity
@@ -328,12 +344,12 @@ jaccard_dm = beta_diversity('jaccard', counts, ids=sample_ids)
 unifrac_dm = beta_diversity('unweighted_unifrac', counts,
                            ids=sample_ids,
                            tree=tree,
-                           otu_ids=feature_ids)
+                           taxa=feature_ids)
 
 weighted_unifrac_dm = beta_diversity('weighted_unifrac', counts,
                                     ids=sample_ids,
                                     tree=tree,
-                                    otu_ids=feature_ids)
+                                    taxa=feature_ids)
 
 # Compute only specific pairs (more efficient)
 pairs = [('Sample1', 'Sample2'), ('Sample1', 'Sample3')]
@@ -345,17 +361,17 @@ partial_dm = partial_beta_diversity('braycurtis', counts,
 ### Rarefaction and Subsampling
 
 ```python
-from skbio.diversity import subsample_counts
+from skbio.stats import subsample_counts
 
-# Rarefy to minimum depth
-min_depth = counts.min(axis=1).max()
+# Rarefy to the minimum per-sample sequencing depth (smallest total count)
+min_depth = counts.sum(axis=1).min()
 rarefied = [subsample_counts(row, n=min_depth) for row in counts]
 
 # Multiple rarefactions for confidence intervals
 import numpy as np
 rarefactions = []
 for i in range(100):
-    rarefied_counts = np.array([subsample_counts(row, n=1000) for row in counts])
+    rarefied_counts = np.array([subsample_counts(row, n=min_depth) for row in counts])
     shannon_rare = alpha_diversity('shannon', rarefied_counts)
     rarefactions.append(shannon_rare)
 
@@ -421,7 +437,7 @@ env = pd.DataFrame({
 # CCA
 cca_results = cca(species, env,
                  sample_ids=['Site1', 'Site2', 'Site3'],
-                 species_ids=['SpeciesA', 'SpeciesB', 'SpeciesC'])
+                 feature_ids=['SpeciesA', 'SpeciesB', 'SpeciesC'])
 
 # Access constrained axes
 cca1 = cca_results.samples['CCA1']
@@ -439,7 +455,7 @@ from skbio.stats.ordination import rda
 # Similar to CCA but for linear relationships
 rda_results = rda(species, env,
                  sample_ids=['Site1', 'Site2', 'Site3'],
-                 species_ids=['SpeciesA', 'SpeciesB', 'SpeciesC'])
+                 feature_ids=['SpeciesA', 'SpeciesB', 'SpeciesC'])
 ```
 
 ## Statistical Tests
@@ -511,24 +527,32 @@ print(f"Sample size: {n}")
 r_spearman, p, n = mantel(dm1, dm2, method='spearman', permutations=999)
 ```
 
-### Partial Mantel Test
+### Pairwise Mantel Test
 
 ```python
-from skbio.stats.distance import mantel
+from skbio.stats.distance import mantel, pwmantel
 
-# Control for a third matrix
-dm3 = DistanceMatrix(...)  # controlling variable
+# Two-sided alternative
+r, p_value, n = mantel(dm1, dm2, method='pearson',
+                       permutations=999, alternative='two-sided')
 
-r_partial, p_value, n = mantel(dm1, dm2, method='pearson',
-                               permutations=999, alternative='two-sided')
+# Pairwise Mantel across several matrices at once
+dm3 = DistanceMatrix(...)
+results = pwmantel([dm1, dm2, dm3], labels=['dm1', 'dm2', 'dm3'],
+                   method='pearson', permutations=999)
 ```
+
+> Note: scikit-bio does not provide a partial Mantel test; `mantel` has no
+> controlling-matrix argument, and `pwmantel` only runs pairwise tests (it does
+> not partial out a third matrix).
 
 ## Distance Matrices
 
 ### Creating and Manipulating Distance Matrices
 
 ```python
-from skbio import DistanceMatrix, DissimilarityMatrix
+from skbio import DistanceMatrix
+from skbio.stats.distance import DissimilarityMatrix
 import numpy as np
 
 # Create from array
@@ -591,9 +615,9 @@ for seq in skbio.io.read('reads.fastq', format='fastq', constructor=skbio.DNA):
 # Write single sequence
 dna.write('output.fasta', format='fasta')
 
-# Write multiple sequences
+# Write multiple sequences (pass a generator; there is no list writer)
 sequences = [dna1, dna2, dna3]
-skbio.io.write(sequences, format='fasta', into='output.fasta')
+skbio.io.write((seq for seq in sequences), format='fasta', into='output.fasta')
 
 # Write with custom line wrapping
 dna.write('output.fasta', format='fasta', max_width=60)
@@ -605,7 +629,7 @@ dna.write('output.fasta', format='fasta', max_width=60)
 from skbio import Table
 
 # Read BIOM table
-table = Table.read('table.biom', format='hdf5')
+table = Table.read('table.biom', format='biom')
 
 # Access data
 sample_ids = table.ids(axis='sample')
@@ -623,7 +647,7 @@ prevalent_features = table.filter(lambda col, id_, md: (col > 0).sum() >= 3,
 relative_abundance = table.norm(axis='sample', inplace=False)
 
 # Write
-table.write('filtered_table.biom', format='hdf5')
+table.write('filtered_table.biom', format='biom')
 ```
 
 ### Format Conversion
@@ -654,11 +678,16 @@ for seq in sequences:
         seen.add(seq.metadata['id'])
 ```
 
-#### Issue: "ValueError: Counts must be integers"
+#### Issue: "Cannot cast array data from dtype('float64') to dtype('int64')"
 ```python
-# Problem: Relative abundances instead of counts
-# Solution: Convert to integer counts or use appropriate metrics
-counts_int = (abundance_table * 1000).astype(int)
+# Problem: A count-based alpha-diversity metric received floats (e.g. relative abundances).
+# These metrics are defined on integer count vectors. `ace` enforces this and raises
+# this TypeError on float input; chao1/shannon/simpson do not strictly enforce it but
+# still expect counts, so passing relative abundances yields meaningless values.
+# (skbio also raises ValueError "Counts must be integers or floating-point
+# numbers." when the input is neither, such as strings.)
+# Solution: pass raw integer counts, not relative abundances.
+counts_int = (abundance_table * 1000).round().astype(int)
 ```
 
 #### Issue: Memory error with large files
@@ -689,7 +718,7 @@ tree_pruned = tree.shear(feature_ids)
 # Solution: Degap sequences first or ensure sequences are unaligned
 seq1_degapped = seq1.degap()
 seq2_degapped = seq2.degap()
-alignment = local_pairwise_align_ssw(seq1_degapped, seq2_degapped)
+msa, score, positions = local_pairwise_align_nucleotide(seq1_degapped, seq2_degapped)
 ```
 
 ### Performance Tips


### PR DESCRIPTION
- the k-mer distance example needs `functools.partial(kmer_distance, k=3)`, since the bare function is missing `k`.
- use a capture group in the `find_with_regex` example so it returns matches.
- correct the rarefaction depth calculation, and document the supported `pair_align` next to the deprecated pairwise aligners.
- correct the BIOM I/O format name (`biom`, not `hdf5`) and clarify that the alpha-diversity metrics expect integer counts.

Each snippet runs on scikit-bio 0.7.2.
