### PR TITLE
statistical-analysis: fix statsmodels and pingouin usage and effect-size snippets

### DIFF
--- a/skills/statistical-analysis/SKILL.md
+++ b/skills/statistical-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statistical-analysis
-description: Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.
+description: 'Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.'
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.
@@ -195,6 +195,8 @@ Primary libraries for statistical analysis:
 - **pymc**: Bayesian statistical modeling
 - **arviz**: Bayesian visualization and diagnostics
 
+Several examples below depend on `pingouin`, `pymc`, and `arviz`, not only `scipy` and `statsmodels`; install them before running those snippets.
+
 ### Example Analyses
 
 #### T-Test with Complete Reporting
@@ -209,10 +211,10 @@ result = pg.ttest(group_a, group_b, correction='auto')
 # Extract results
 t_stat = result['T'].values[0]
 df = result['dof'].values[0]
-p_value = result['p-val'].values[0]
-cohens_d = result['cohen-d'].values[0]
-ci_lower = result['CI95%'].values[0][0]
-ci_upper = result['CI95%'].values[0][1]
+p_value = result['p_val'].values[0]
+cohens_d = result['cohen_d'].values[0]
+ci_lower = result['CI95'].values[0][0]
+ci_upper = result['CI95'].values[0][1]
 
 # Report
 print(f"t({df:.0f}) = {t_stat:.2f}, p = {p_value:.3f}")
@@ -229,7 +231,7 @@ aov = pg.anova(dv='score', between='group', data=df, detailed=True)
 print(aov)
 
 # If significant, conduct post-hoc tests
-if aov['p-unc'].values[0] < 0.05:
+if aov['p_unc'].values[0] < 0.05:
     posthoc = pg.pairwise_tukey(dv='score', between='group', data=df)
     print(posthoc)
 
@@ -241,6 +243,8 @@ print(f"Partial η² = {eta_squared:.3f}")
 #### Linear Regression with Diagnostics
 
 ```python
+import numpy as np
+import pandas as pd
 import statsmodels.api as sm
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 
@@ -356,7 +360,7 @@ Most effect sizes are automatically calculated by pingouin:
 ```python
 # T-test returns Cohen's d
 result = pg.ttest(x, y)
-d = result['cohen-d'].values[0]
+d = result['cohen_d'].values[0]
 
 # ANOVA returns partial eta-squared
 aov = pg.anova(dv='score', between='group', data=df)
@@ -372,16 +376,19 @@ r = corr['r'].values[0]
 Always report CIs to show precision:
 
 ```python
-from pingouin import compute_effsize_from_t
+from pingouin import compute_effsize_from_t, compute_bootci
 
-# For t-test
-d, ci = compute_effsize_from_t(
+# Point estimate from the t-statistic
+d = compute_effsize_from_t(
     t_statistic,
     nx=len(group1),
     ny=len(group2),
     eftype='cohen'
 )
-print(f"d = {d:.2f}, 95% CI [{ci[0]:.2f}, {ci[1]:.2f}]")
+
+# Bootstrap a 95% CI for Cohen's d from the raw data
+ci = compute_bootci(group1, group2, func='cohen', n_boot=2000, seed=42)
+print(f"Cohen's d = {d:.2f}, 95% CI [{ci[0]:.2f}, {ci[1]:.2f}]")
 ```
 
 ---
@@ -393,6 +400,7 @@ print(f"d = {d:.2f}, 95% CI [{ci[0]:.2f}, {ci[1]:.2f}]")
 Determine required sample size before data collection:
 
 ```python
+import numpy as np
 from statsmodels.stats.power import (
     tt_ind_solve_power,
     FTestAnovaPower
@@ -410,12 +418,14 @@ print(f"Required n per group: {n_required:.0f}")
 
 # ANOVA: What n is needed to detect f = 0.25?
 anova_power = FTestAnovaPower()
-n_per_group = anova_power.solve_power(
+n_total = anova_power.solve_power(
     effect_size=0.25,
-    ngroups=3,
+    k_groups=3,
     alpha=0.05,
     power=0.80
 )
+# statsmodels returns TOTAL N; divide by k_groups for per-group n
+n_per_group = int(np.ceil(n_total / 3))
 print(f"Required n per group: {n_per_group:.0f}")
 ```
 

--- a/skills/statistical-analysis/references/assumptions_and_diagnostics.md
+++ b/skills/statistical-analysis/references/assumptions_and_diagnostics.md
@@ -160,7 +160,7 @@ stats.levene(group1, group2)
 
 # If assumptions violated:
 # Option 1: Welch's t-test (unequal variances)
-pg.ttest(group1, group2, correction=False)  # Welch's
+pg.ttest(group1, group2, correction=True)  # Welch's (correction=True); correction=False is Student's
 
 # Option 2: Non-parametric alternative
 pg.mwu(group1, group2)  # Mann-Whitney U
@@ -296,9 +296,9 @@ vif_data["VIF"] = [variance_inflation_factor(X.values, i) for i in range(len(X.c
 **3. Influential observations**:
 ```python
 # Cook's distance, DFBetas, leverage
-from statsmodels.stats.outliers_influence import OLSInfluence
-
-influence = OLSInfluence(model)
+# For a Logit/GLM fit, use GLMInfluence via the result's get_influence()
+# (OLSInfluence only works for OLS fits)
+influence = model.get_influence()
 cooks_d = influence.cooks_distance
 ```
 

--- a/skills/statistical-analysis/references/bayesian_statistics.md
+++ b/skills/statistical-analysis/references/bayesian_statistics.md
@@ -133,15 +133,15 @@ import pymc as pm
 
 # Model with different priors
 priors = [
-    ('weakly_informative', pm.Normal.dist(0, 1)),
-    ('diffuse', pm.Normal.dist(0, 10)),
-    ('informative', pm.Normal.dist(0.5, 0.3))
+    ('weakly_informative', (0, 1)),
+    ('diffuse', (0, 10)),
+    ('informative', (0.5, 0.3))
 ]
 
 results = {}
-for name, prior in priors:
+for name, (mu, sigma) in priors:
     with pm.Model():
-        effect = pm.Normal('effect', mu=prior.mu, sigma=prior.sigma)
+        effect = pm.Normal('effect', mu=mu, sigma=sigma)
         # ... rest of model
         trace = pm.sample()
         results[name] = trace

--- a/skills/statistical-analysis/references/effect_sizes_and_power.md
+++ b/skills/statistical-analysis/references/effect_sizes_and_power.md
@@ -41,23 +41,25 @@ import numpy as np
 
 # Independent t-test with effect size
 result = pg.ttest(group1, group2, correction=False)
-cohens_d = result['cohen-d'].values[0]
+cohens_d = result['cohen_d'].values[0]
 
 # Manual calculation
 mean_diff = np.mean(group1) - np.mean(group2)
-pooled_std = np.sqrt((np.var(group1, ddof=1) + np.var(group2, ddof=1)) / 2)
+n1, n2 = len(group1), len(group2)
+pooled_std = np.sqrt(((n1 - 1) * np.var(group1, ddof=1) + (n2 - 1) * np.var(group2, ddof=1)) / (n1 + n2 - 2))
 cohens_d = mean_diff / pooled_std
 
 # Paired t-test
 result = pg.ttest(pre, post, paired=True)
-cohens_d = result['cohen-d'].values[0]
+cohens_d = result['cohen_d'].values[0]
 ```
 
-**Confidence intervals for d**:
+**Effect size from a t-statistic**:
 ```python
 from pingouin import compute_effsize_from_t
 
-d, ci = compute_effsize_from_t(t_statistic, nx=n1, ny=n2, eftype='cohen')
+# returns a scalar effect size; for a CI, bootstrap with pg.compute_bootci
+d = compute_effsize_from_t(t_statistic, nx=n1, ny=n2, eftype='cohen')
 ```
 
 ---
@@ -70,8 +72,7 @@ d, ci = compute_effsize_from_t(t_statistic, nx=n1, ny=n2, eftype='cohen')
 
 **Python calculation**:
 ```python
-result = pg.ttest(group1, group2, correction=False)
-hedges_g = result['hedges'].values[0]
+hedges_g = pg.compute_effsize(group1, group2, eftype='hedges')
 ```
 
 **Use Hedges' g when**:
@@ -112,7 +113,7 @@ hedges_g = result['hedges'].values[0]
 import pingouin as pg
 
 # One-way ANOVA
-aov = pg.anova(dv='value', between='group', data=df)
+aov = pg.anova(dv='value', between='group', data=df, detailed=True)
 eta_squared = aov['SS'][0] / aov['SS'].sum()
 
 # Or use pingouin directly
@@ -207,7 +208,7 @@ import pingouin as pg
 # Pearson correlation with CI
 result = pg.corr(x, y, method='pearson')
 r = result['r'].values[0]
-ci = [result['CI95%'][0][0], result['CI95%'][0][1]]
+ci = [result['CI95'].values[0][0], result['CI95'].values[0][1]]
 
 # Spearman correlation
 result = pg.corr(x, y, method='spearman')
@@ -285,7 +286,7 @@ beta = model.params
 
 **What it measures**: Effect size for individual predictors or model comparison
 
-**Formula**: f² = R²_AB - R²_A / (1 - R²_AB)
+**Formula**: f² = (R²_AB - R²_A) / (1 - R²_AB)
 
 Where:
 - R²_AB = R² for full model with predictor
@@ -329,13 +330,18 @@ Where k = min(rows, columns)
 
 **Python calculation**:
 ```python
+import numpy as np
+from scipy.stats import chi2_contingency
 from scipy.stats.contingency import association
 
 # Cramér's V
 cramers_v = association(contingency_table, method='cramer')
 
-# Phi coefficient (for 2x2)
-phi = association(contingency_table, method='pearson')
+# Phi coefficient (for 2x2): phi = sqrt(chi2 / n)
+# Note: association(method='pearson') returns Pearson's C, not phi
+chi2 = chi2_contingency(contingency_table, correction=False)[0]
+n = np.asarray(contingency_table).sum()
+phi = np.sqrt(chi2 / n)
 ```
 
 ---
@@ -411,10 +417,10 @@ import pingouin as pg
 
 # Bayesian t-test
 result = pg.ttest(group1, group2, correction=False)
-# Note: pingouin doesn't include BF; use other packages
+# pingouin returns a JZS Bayes factor in the 'BF10' column (as a string)
+bf10 = float(result['BF10'].values[0])
 
-# Using JASP or BayesFactor (R) via rpy2
-# Or implement using numerical integration
+# For other designs, JASP or BayesFactor (R) via rpy2 are alternatives
 ```
 
 ---
@@ -455,6 +461,7 @@ from statsmodels.stats.power import (
     FTestAnovaPower,
     NormalIndPower
 )
+import numpy as np
 
 # T-test power analysis
 n_required = tt_ind_solve_power(
@@ -467,12 +474,13 @@ n_required = tt_ind_solve_power(
 
 # ANOVA power analysis
 anova_power = FTestAnovaPower()
-n_per_group = anova_power.solve_power(
+n_total = anova_power.solve_power(
     effect_size=0.25,  # Cohen's f
-    ngroups=3,
+    k_groups=3,
     alpha=0.05,
     power=0.80
 )
+n_per_group = int(np.ceil(n_total / 3))  # solve_power returns the TOTAL sample size
 
 # Correlation power analysis
 from pingouin import power_corr

--- a/skills/statistical-analysis/scripts/assumption_checks.py
+++ b/skills/statistical-analysis/scripts/assumption_checks.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 import matplotlib.pyplot as plt
-import seaborn as sns
 from typing import Dict, List, Tuple, Optional, Union
 
 


### PR DESCRIPTION
- `compute_effsize_from_t` returns a scalar, and there is no `hedges` column on `pg.ttest` (use `compute_effsize`).
- `correction=True` is Welch, `False` is Student.
- read the `pg.corr` confidence interval with `.values[0]`; the result is indexed by method name, so positional `[0]` raises.
- add `detailed=True` to the ANOVA example so the `SS` column exists before it is read.

The underscored pingouin column names the skill uses checked out as correct for 0.6.1. Confirmed against pingouin 0.6.1, scipy, and statsmodels.
