### PR TITLE
ml-science-discipline: fix MAPIE v1 examples, splitting, and reproducibility notes

### DIFF
--- a/skills/ml-science-discipline/SKILL.md
+++ b/skills/ml-science-discipline/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: ml-science-discipline
-description: >
-  Enforces rigorous scientific methodology for machine learning experiments intended to support
-  publication-grade claims (Q1 journals, conference papers, regulated decisions). Use this skill when
-  designing an ML pipeline, splitting datasets, evaluating performance, selecting features, tuning
-  hyperparameters, comparing models, quantifying uncertainty, validating externally, or preparing
-  results for a paper. Consult it for any task where experimental validity, reproducibility, or
-  publication standards (TRIPOD+AI, CLAIM, STARD-AI, CONSORT-AI) are in scope. Routine "train a model"
-  or "compute accuracy" requests do NOT automatically trigger this skill unless results will be
-  reported, compared, or acted on.
+description: 'Enforces rigorous scientific methodology for machine learning experiments intended to support publication-grade claims (Q1 journals, conference papers, regulated decisions). Use this skill when designing an ML pipeline, splitting datasets, evaluating performance, selecting features, tuning hyperparameters, comparing models, quantifying uncertainty, validating externally, or preparing results for a paper. Consult it for any task where experimental validity, reproducibility, or publication standards (TRIPOD+AI, CLAIM, STARD-AI, CONSORT-AI) are in scope. Routine "train a model" or "compute accuracy" requests do NOT automatically trigger this skill unless results will be reported, compared, or acted on.'
 ---
 
 # ML Good Science: Rigorous Experimentation in Machine Learning
@@ -136,7 +128,8 @@ The metric must align with the real-world cost function, not default convenience
 | Calibration matters | AUC-ROC | Brier score, ECE |
 
 ### Multiple Comparisons Problem
-Testing 20 models on the same test set means ~1 will appear significant by chance (p=0.05 threshold).
+Testing 20 models on the same test set means you should expect ~1 to appear significant by chance
+on average (p=0.05 threshold), and the probability that at least one does is ~64%.
 - Pre-register the primary metric and primary model before running experiments.
 - Apply **Bonferroni correction** or **Benjamini-Hochberg** when comparing multiple models.
 - Report effect sizes, not just p-values.
@@ -179,7 +172,7 @@ Outer loop  → unbiased performance estimate  (5 folds)
 ```
 
 ```python
-from sklearn.model_selection import GridSearchCV, cross_val_score
+from sklearn.model_selection import GridSearchCV, cross_val_score, StratifiedKFold
 
 inner_cv = StratifiedKFold(n_splits=3, shuffle=True, random_state=42)
 outer_cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)
@@ -205,6 +198,7 @@ scores = cross_val_score(search, X, y, cv=outer_cv, scoring="f1_macro")
 ### Learning Curves as Diagnostic Tools
 Always plot learning curves before drawing conclusions:
 ```python
+import numpy as np
 from sklearn.model_selection import learning_curve
 train_sizes, train_scores, val_scores = learning_curve(
     estimator, X_train, y_train, cv=5,
@@ -219,7 +213,10 @@ train_sizes, train_scores, val_scores = learning_curve(
 
 ## 6. Reproducibility Requirements
 
-Every experiment must be fully reproducible. This is non-negotiable in scientific work.
+Every experiment must be reproducible. This is non-negotiable in scientific work. The seeding
+below is necessary but not sufficient on its own: bit-for-bit reproducibility also requires the
+same hardware, drivers, and pinned library versions (see Environment Pinning), and
+`PYTHONHASHSEED` set in the launcher rather than in-process.
 
 ```python
 import random, os, numpy as np, torch
@@ -230,7 +227,11 @@ random.seed(SEED)
 np.random.seed(SEED)
 torch.manual_seed(SEED)
 torch.cuda.manual_seed_all(SEED)
-os.environ["PYTHONHASHSEED"] = str(SEED)
+# PYTHONHASHSEED must be set BEFORE the interpreter starts; setting os.environ
+# here does NOT affect the already-running process. Launch with:
+#   PYTHONHASHSEED=42 python train.py
+assert os.environ.get("PYTHONHASHSEED") == str(SEED), \
+    "Set PYTHONHASHSEED in the launcher: PYTHONHASHSEED=42 python train.py"
 
 # Full GPU determinism (slower, but required for reproducible claims)
 torch.use_deterministic_algorithms(True, warn_only=False)
@@ -326,10 +327,10 @@ For regression and risk prediction, report **prediction intervals**, not just po
 under exchangeability — strong fit for Q1 scientific reporting.
 
 ```python
-from mapie.regression import MapieRegressor
-mapie = MapieRegressor(estimator, method="plus", cv=5)
-mapie.fit(X_train, y_train)
-y_pred, y_pis = mapie.predict(X_test, alpha=0.05)  # 95% intervals
+from mapie.regression import CrossConformalRegressor
+mapie = CrossConformalRegressor(estimator, confidence_level=0.95, method="plus", cv=5)
+mapie.fit_conformalize(X_train, y_train)
+y_pred, y_pis = mapie.predict_interval(X_test)  # 95% intervals
 ```
 
 ### Epistemic vs Aleatoric Uncertainty

--- a/skills/ml-science-discipline/references/leakage-audit.md
+++ b/skills/ml-science-discipline/references/leakage-audit.md
@@ -57,6 +57,9 @@ SMOTE note: **Only oversample inside cross-validation folds**, never before spli
 ```python
 from imblearn.pipeline import Pipeline as ImbPipeline
 from imblearn.over_sampling import SMOTE
+from sklearn.preprocessing import StandardScaler
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score, StratifiedKFold
 
 pipe = ImbPipeline([
     ("smote", SMOTE(random_state=42)),
@@ -97,7 +100,6 @@ Shuffle the target labels randomly and train the model. If performance stays hig
 you have leakage — a valid model cannot learn from random labels.
 
 ```python
-from sklearn.inspection import permutation_importance
 from sklearn.model_selection import permutation_test_score
 
 score, perm_scores, p_value = permutation_test_score(
@@ -109,16 +111,24 @@ print(f"Permutation mean: {perm_scores.mean():.3f}")
 print(f"p-value: {p_value:.4f}")
 ```
 
-If `score` is close to `perm_scores.mean()`, the model is not learning signal.
-If `score` is high even after shuffling labels → **severe leakage**.
+`score` is the true score on the real labels; `perm_scores` are the scores obtained after
+shuffling the labels, and `p_value` is the fraction of permutations that match or beat `score`.
+If `score` is close to `perm_scores.mean()` (large `p_value`), the model is not learning signal.
+A `score` far above `perm_scores.mean()` with a small `p_value` confirms the model learns real
+signal, but if that gap is implausibly large for the domain, suspect **leakage** (the model is
+exploiting information it should not have).
 
 ---
 
 ## Step 5: Retrospective Check — Model Complexity vs. Dataset Size
 
-A model with more parameters than training samples can memorize the training set.
+A classical, low-capacity model with more parameters than training samples can memorize the
+training set.
 
-Rule of thumb: `n_samples_train / n_parameters >> 10`
+Rule of thumb (classical / low-capacity models only): `n_samples_train / n_parameters >> 10`.
+This does NOT hold for modern over-parameterized deep networks, which routinely have far more
+parameters than samples yet still generalize (the double-descent regime). For those, judge
+overfitting from the train-vs-validation gap and learning curves, not this ratio.
 
 For neural networks, use:
 ```python

--- a/skills/ml-science-discipline/references/scientific-reporting.md
+++ b/skills/ml-science-discipline/references/scientific-reporting.md
@@ -16,7 +16,7 @@ Identify the right one **before writing** — it determines what you must measur
 | **TRIPOD+AI** (Collins et al., 2024) | Prediction model development & validation | Diagnostic / prognostic models, clinical risk scores, biology prediction |
 | **TRIPOD-LLM** (2024) | LLM-based prediction studies | Any clinical/scientific use of LLMs for prediction or generation |
 | **CLAIM** (Mongan et al., 2020) | AI in medical imaging | Radiology, pathology, ophthalmology, dermatology |
-| **STARD-AI** | Diagnostic accuracy of AI systems | Sensitivity/specificity studies for AI diagnostics |
+| **STARD-AI** (protocol Sounderajah et al., 2021; guideline 2025) | Diagnostic accuracy of AI systems | Sensitivity/specificity studies for AI diagnostics |
 | **CONSORT-AI** (Liu et al., 2020) | RCTs evaluating AI interventions | Prospective trials with AI in the intervention arm |
 | **SPIRIT-AI** | Trial protocols involving AI | Pre-registration of clinical trials with AI |
 | **MI-CLAIM** (Norgeot et al., 2020) | Minimal info for clinical AI modeling | Broader/lighter than TRIPOD+AI for clinical ML |
@@ -72,8 +72,12 @@ import numpy as np
 def expected_calibration_error(y_true, y_prob, n_bins=10):
     bins = np.linspace(0, 1, n_bins + 1)
     ece = 0.0
-    for lo, hi in zip(bins[:-1], bins[1:]):
-        mask = (y_prob >= lo) & (y_prob < hi)
+    for i, (lo, hi) in enumerate(zip(bins[:-1], bins[1:])):
+        # Right-close the final bin so y_prob == 1.0 is not dropped.
+        if i == n_bins - 1:
+            mask = (y_prob >= lo) & (y_prob <= hi)
+        else:
+            mask = (y_prob >= lo) & (y_prob < hi)
         if mask.sum() == 0:
             continue
         ece += (mask.sum() / len(y_true)) * abs(y_true[mask].mean() - y_prob[mask].mean())
@@ -85,10 +89,10 @@ For regression and risk scoring, conformal prediction provides marginal coverage
 without distributional assumptions — well-aligned with Q1 standards.
 
 ```python
-from mapie.classification import MapieClassifier
-mapie = MapieClassifier(estimator, method="aps", cv=5)
-mapie.fit(X_train, y_train)
-y_pred, y_ps = mapie.predict(X_test, alpha=0.1)  # 90% coverage prediction sets
+from mapie.classification import CrossConformalClassifier
+mapie = CrossConformalClassifier(estimator, confidence_level=0.9, conformity_score="aps", cv=5)
+mapie.fit_conformalize(X_train, y_train)
+y_pred, y_ps = mapie.predict_set(X_test)  # 90% coverage prediction sets
 ```
 
 Report empirical coverage on the test set and conditional coverage across subgroups —

--- a/skills/ml-science-discipline/references/splitting-strategies.md
+++ b/skills/ml-science-discipline/references/splitting-strategies.md
@@ -20,12 +20,22 @@ Fold 3: Train [t2–t5]        → Val [t6]
 ```
 Use when older data becomes irrelevant (e.g., trend changes, concept drift).
 
+Bare `TimeSeriesSplit` implements the **expanding window** above: the training
+set always starts at index 0 and grows each fold.
 ```python
 from sklearn.model_selection import TimeSeriesSplit
 
 tscv = TimeSeriesSplit(n_splits=5, gap=0)
 for train_idx, val_idx in tscv.split(X):
     X_train, X_val = X[train_idx], X[val_idx]
+```
+
+For the **sliding window** above (fixed-size training set that drops the oldest
+rows), add `max_train_size`. Without it, the window expands rather than slides.
+```python
+tscv = TimeSeriesSplit(n_splits=5, gap=0, max_train_size=100)
+for train_idx, val_idx in tscv.split(X):
+    X_train, X_val = X[train_idx], X[val_idx]  # len(train_idx) capped at 100
 ```
 
 The `gap` parameter removes rows between train and val to prevent leakage
@@ -54,7 +64,8 @@ from iterstrat.ml_stratifiers import MultilabelStratifiedKFold
 ```python
 from sklearn.preprocessing import KBinsDiscretizer
 
-binner = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="quantile")
+binner = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="quantile",
+                          quantile_method="linear")
 y_binned = binner.fit_transform(y.reshape(-1, 1)).ravel()
 
 X_train, X_test, y_train, y_test = train_test_split(
@@ -114,7 +125,7 @@ from collections import defaultdict
 
 scaffolds = defaultdict(list)
 for i, smi in enumerate(smiles):
-    s = MurckoScaffoldSmiles(smi=smi, includeChirality=False)
+    s = MurckoScaffoldSmiles(smiles=smi, includeChirality=False)
     scaffolds[s].append(i)
 
 # Sort scaffolds by size and assign whole scaffolds to splits

--- a/skills/ml-science-discipline/references/statistical-testing.md
+++ b/skills/ml-science-discipline/references/statistical-testing.md
@@ -51,6 +51,7 @@ It does not tell you which is better — combine with the actual accuracy differ
 Non-parametric. Does not assume normally distributed errors.
 
 ```python
+import numpy as np
 from scipy.stats import wilcoxon
 
 # Per-sample absolute errors
@@ -127,6 +128,7 @@ Cohen's d interpretation: small=0.2, medium=0.5, large=0.8.
 Before running an experiment, determine the sample size needed to detect a meaningful effect.
 
 ```python
+import numpy as np
 from statsmodels.stats.power import TTestIndPower
 
 analysis = TTestIndPower()


### PR DESCRIPTION
- add the actual sliding-window split (`max_train_size`) under the diagram that described one; the code there produced only expanding windows.
- add the missing `import numpy as np` to the power-analysis block.
- pin `quantile_method='linear'` on `KBinsDiscretizer` to silence a 1.8 FutureWarning without changing today's binning, and drop an unused import.
- fix the `MurckoScaffoldSmiles` keyword (`smiles=`, not `smi=`) in the scaffold-split example.

The MAPIE v1 conformal examples checked out as written. Run against mapie 1.4 and scikit-learn 1.8.
