### PR TITLE
shap: fix plot defaults, explainer docs, and cohort indexing (0.51)

### DIFF
--- a/skills/shap/SKILL.md
+++ b/skills/shap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shap
-description: Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter, force, heatmap), debugging models, analyzing model bias or fairness, comparing models, or implementing explainable AI. Works with tree-based models (XGBoost, LightGBM, Random Forest), deep learning (TensorFlow, PyTorch), linear models, and any black-box model.
+description: 'Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter, force, heatmap), debugging models, analyzing model bias or fairness, comparing models, or implementing explainable AI. Works with tree-based models (XGBoost, LightGBM, Random Forest), deep learning (TensorFlow, PyTorch), linear models, and any black-box model.'
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.
@@ -79,6 +79,12 @@ shap_values = explainer(X_test)
 # - values: SHAP values (feature attributions)
 # - base_values: Expected model output (baseline)
 # - data: Original feature values
+
+# Output shape is model-family-dependent:
+# - XGBoost / LightGBM / gradient boosting: values is 2D (n_samples, n_features)
+# - scikit-learn forests (RandomForest, etc.): values is 3D
+#   (n_samples, n_features, n_classes), carrying a trailing class axis
+# Select a class before plotting 3D outputs, e.g. shap_values[..., 1]
 ```
 
 ### Step 3: Visualize Results
@@ -100,6 +106,8 @@ shap.plots.waterfall(shap_values[0])
 # Force plot - additive force visualization
 shap.plots.force(shap_values[0])
 ```
+
+> **Classifier note**: For scikit-learn classifiers (e.g. RandomForestClassifier), `explainer(X)` returns a 3D Explanation `(n_samples, n_features, n_classes)`. Select a class before passing to a plot, otherwise these calls error. For a single prediction use `shap_values[0, :, 1]`; for the global plots above use `shap_values[..., 1]` (the example here uses an XGBoost classifier, whose output is already 2D).
 
 **For Feature Relationships**:
 ```python
@@ -132,6 +140,9 @@ This skill supports several common workflows. Choose the workflow that matches t
 # Step 1-2: Setup
 explainer = shap.TreeExplainer(model)
 shap_values = explainer(X_test)
+
+# For sklearn classifiers shap_values is 3D (carries a trailing class axis);
+# select a class first, e.g. shap_values = shap_values[..., 1]
 
 # Step 3: Global importance
 shap.plots.beeswarm(shap_values)
@@ -249,7 +260,7 @@ Final prediction: 0.30 + 0.15 + 0.10 - 0.05 = 0.50
 - Or use kmeans to select representative samples
 - For DeepExplainer/KernelExplainer: 100-1000 samples balances accuracy and speed
 
-**Impact**: Baseline affects SHAP value magnitudes but not relative importance
+**Impact**: The background choice can affect SHAP value magnitudes, signs, and feature rankings
 
 ### Model Output Types
 
@@ -259,7 +270,7 @@ Final prediction: 0.30 + 0.15 + 0.10 - 0.05 = 0.50
 - **Probability**: For classification probability
 - **Log-odds**: For logistic regression (before sigmoid)
 
-**Example**: XGBoost classifiers explain margin output (log-odds) by default. To explain probabilities, use `model_output="probability"` in TreeExplainer.
+**Example**: XGBoost and gradient-boosting classifiers explain margin output (log-odds) by default, while scikit-learn forests (e.g. RandomForest) explain probability. To explain probabilities, construct TreeExplainer with `model_output="probability"`, `data=background`, and `feature_perturbation="interventional"` (the no-background `tree_path_dependent` default only supports `model_output="raw"`).
 
 ## Common Patterns
 
@@ -269,6 +280,10 @@ Final prediction: 0.30 + 0.15 + 0.10 - 0.05 = 0.50
 # 1. Setup
 explainer = shap.TreeExplainer(model)
 shap_values = explainer(X_test)
+
+# For sklearn classifiers shap_values is 3D (trailing class axis);
+# select a class first so the plots and .values math below stay 2D
+# shap_values = shap_values[..., 1]
 
 # 2. Global importance
 shap.plots.beeswarm(shap_values)
@@ -288,13 +303,15 @@ for i in range(5):
 
 ```python
 # Define cohorts
+# .values converts the pandas boolean Series to a numpy array;
+# indexing an Explanation with a Series directly raises a ValueError.
 cohort1_mask = X_test['Group'] == 'A'
 cohort2_mask = X_test['Group'] == 'B'
 
 # Compare feature importance
 shap.plots.bar({
-    "Group A": shap_values[cohort1_mask],
-    "Group B": shap_values[cohort2_mask]
+    "Group A": shap_values[cohort1_mask.values],
+    "Group B": shap_values[cohort2_mask.values]
 })
 ```
 
@@ -304,6 +321,9 @@ shap.plots.bar({
 # Find errors
 errors = model.predict(X_test) != y_test
 error_indices = np.where(errors)[0]
+
+# For sklearn classifiers shap_values is 3D (trailing class axis);
+# select a class first, e.g. shap_values = shap_values[..., 1]
 
 # Explain errors
 for idx in error_indices[:5]:
@@ -324,7 +344,7 @@ for idx in error_indices[:5]:
 3. `DeepExplainer` - Fast for neural networks
 4. `GradientExplainer` - Fast for neural networks
 5. `KernelExplainer` - Slow (use only when necessary)
-6. `PermutationExplainer` - Very slow but accurate
+6. `PermutationExplainer` - Slow, model-agnostic approximation
 
 ### Optimization Strategies
 
@@ -446,7 +466,7 @@ Complete guide to all explainer classes:
 - `KernelExplainer` - Model-agnostic (works with any model)
 - `LinearExplainer` - Fast explanations for linear models
 - `GradientExplainer` - Gradient-based for neural networks
-- `PermutationExplainer` - Exact but slow for any model
+- `PermutationExplainer` - Model-agnostic approximation, slow for any model
 
 Includes: Constructor parameters, methods, supported models, when to use, examples, performance considerations.
 
@@ -532,31 +552,31 @@ Includes: Mathematical foundations, proofs, comparisons, advanced topics.
 
 8. **Check for data leakage**: Unexpectedly high feature importance may indicate data quality issues
 
-9. **Consider feature correlations**: Use TreeExplainer's correlation-aware options or feature clustering for redundant features
+9. **Consider feature correlations**: Use TreeExplainer's `feature_perturbation` choices (interventional vs tree_path_dependent) or feature clustering for redundant features
 
 10. **Remember SHAP shows association, not causation**: Use domain knowledge for causal interpretation
 
 ## Installation
 
 ```bash
-# Basic installation
+# Core installation (no plotting; shap.plots.* will be unavailable)
 uv pip install shap
 
-# With visualization dependencies
-uv pip install shap matplotlib
+# With visualization dependencies (required for shap.plots.*)
+uv pip install "shap[plots]"
 
 # Latest version
-uv pip install -U shap
+uv pip install -U "shap[plots]"
 ```
 
-**Dependencies**: numpy, pandas, scikit-learn, matplotlib, scipy
+**Dependencies**: numpy, pandas, scikit-learn, scipy
 
-**Optional**: xgboost, lightgbm, tensorflow, torch (depending on model types)
+**Optional**: matplotlib and ipython (via the `plots` extra, required for `shap.plots.*`); xgboost, lightgbm, tensorflow, torch (depending on model types)
 
 ## Additional Resources
 
 - **Official Documentation**: https://shap.readthedocs.io/
-- **GitHub Repository**: https://github.com/slundberg/shap
+- **GitHub Repository**: https://github.com/shap/shap
 - **Original Paper**: Lundberg & Lee (2017) - "A Unified Approach to Interpreting Model Predictions"
 - **Nature MI Paper**: Lundberg et al. (2020) - "From local explanations to global understanding with explainable AI for trees"
 

--- a/skills/shap/references/explainers.md
+++ b/skills/shap/references/explainers.md
@@ -182,9 +182,11 @@ shap_values = explainer.shap_values(X_test[:10])
 **Constructor Parameters**:
 - `model`: Linear model or tuple of (coefficients, intercept)
 - `masker`: Background data for feature correlation
-- `feature_perturbation`: How to handle feature correlations
+- `feature_perturbation`: How to handle feature correlations (default `None`)
   - `"interventional"`: Assumes feature independence
   - `"correlation_dependent"`: Accounts for feature correlations
+  - DEPRECATED in 0.51.0: this parameter is deprecated in favor of passing the
+    appropriate tabular masker and will be removed in a future release.
 
 **Supported Models**:
 - scikit-learn linear models (LinearRegression, LogisticRegression, Ridge, Lasso, ElasticNet)
@@ -251,10 +253,12 @@ shap_values = explainer.shap_values(X_test[:10])
 **Constructor Parameters**:
 - `model`: Prediction function
 - `masker`: Background data or masker object
+
+**Call Parameters** (passed when calling the explainer, e.g. `explainer(X, max_evals=...)`):
 - `max_evals`: Maximum number of model evaluations per sample
 
 **When to Use**:
-- When exact Shapley values are needed but specialized explainers aren't available
+- When a model-agnostic approximation of Shapley values is needed and specialized explainers aren't available
 - For small feature sets where permutation is tractable
 - As a more accurate alternative to KernelExplainer (but slower)
 

--- a/skills/shap/references/plots.md
+++ b/skills/shap/references/plots.md
@@ -6,6 +6,8 @@ This document provides comprehensive information about all SHAP plotting functio
 
 SHAP provides diverse visualization tools for explaining model predictions at both individual and global levels. Each plot type serves specific purposes in understanding feature importance, interactions, and prediction mechanisms.
 
+> **Classifier note**: For scikit-learn classifiers (e.g. RandomForestClassifier), `explainer(X)` returns a 3D Explanation `(n_samples, n_features, n_classes)`. Every plot below (waterfall, beeswarm, bar, scatter, heatmap, violin) expects a 2D global or 1D single-sample Explanation, so select a class first: use `shap_values[..., 1]` for the global plots and `shap_values[0, :, 1]` for a single-prediction plot. The `shap_values[i]` and `shap_values[:, "Feature"]` forms in the examples assume a 2D output (XGBoost / LightGBM / gradient boosting); for forests, slice the class axis first.
+
 ## Plot Types
 
 ### Waterfall Plots
@@ -56,7 +58,7 @@ shap.plots.waterfall(shap_values[0], max_display=20)
 
 **Purpose**: Information-dense summary of how top features impact model output across the entire dataset, combining feature importance with value distributions.
 
-**Function**: `shap.plots.beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0), color=None, show=True)`
+**Function**: `shap.plots.beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0), clustering=None, cluster_threshold=0.5, color=None, alpha=1.0, ax=None, show=True, log_scale=False, color_bar=True, s=16, plot_size="auto", group_remaining_features=True)`
 
 **Key Parameters**:
 - `shap_values`: Explanation object containing multiple samples
@@ -104,7 +106,7 @@ shap.plots.beeswarm(shap_values, color=plt.cm.viridis)
 
 **Purpose**: Display feature importance as mean absolute SHAP values, providing clean, simple visualizations of global feature impact.
 
-**Function**: `shap.plots.bar(shap_values, max_display=10, clustering=None, clustering_cutoff=0.5, show=True)`
+**Function**: `shap.plots.bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clustering_cutoff=0.5, show_data="auto", ax=None, show=True)`
 
 **Key Parameters**:
 - `shap_values`: Explanation object (can be single instance, global, or cohorts)
@@ -136,10 +138,12 @@ shap.plots.bar(shap_values[0])
 Compares feature importance across subgroups by passing a dictionary of Explanation objects.
 
 ```python
-# Compare cohorts
+# Compare cohorts. mask_A/mask_B are boolean selectors (e.g. X_test["group"] == "A").
+# Pass .values so the Explanation is indexed with a numpy array; indexing an
+# Explanation with a pandas Series raises a ValueError.
 cohorts = {
-    "Group A": shap_values[mask_A],
-    "Group B": shap_values[mask_B]
+    "Group A": shap_values[mask_A.values],
+    "Group B": shap_values[mask_B.values]
 }
 shap.plots.bar(cohorts)
 ```
@@ -220,7 +224,7 @@ shap.plots.force(
 **Key Parameters**:
 - `shap_values`: Explanation object, can specify feature with subscript (e.g., `shap_values[:, "Age"]`)
 - `color`: Feature to use for coloring points (string name or Explanation object)
-- `hist`: Show histogram of feature values on y-axis
+- `hist`: Show a light histogram of feature values along the x-axis
 - `alpha`: Point transparency (useful for dense plots)
 
 **Visual Elements**:
@@ -257,12 +261,12 @@ shap.plots.scatter(shap_values[:, "Age"], alpha=0.5)
 
 **Purpose**: Visualize SHAP values for multiple samples simultaneously, showing feature impacts across instances.
 
-**Function**: `shap.plots.heatmap(shap_values, instance_order=None, feature_values=None, max_display=10, show=True)`
+**Function**: `shap.plots.heatmap(shap_values, instance_order=Explanation.hclust, feature_values=Explanation.abs.mean(0), max_display=10, show=True)`
 
 **Key Parameters**:
 - `shap_values`: Explanation object
-- `instance_order`: How to order instances (can be Explanation object for custom ordering)
-- `feature_values`: Display feature values on hover
+- `instance_order`: How to order instances (default: hierarchical clustering, `Explanation.hclust`; pass an array/Explanation to override)
+- `feature_values`: Per-feature global importance used to order features (default: mean absolute SHAP value)
 - `max_display`: Maximum features to display
 
 **Visual Elements**:
@@ -293,7 +297,9 @@ shap.plots.heatmap(shap_values[:100])
 
 **Purpose**: Similar to beeswarm plots but uses violin (kernel density) visualization instead of individual dots.
 
-**Function**: `shap.plots.violin(shap_values, features=None, feature_names=None, max_display=10, show=True)`
+**Function**: `shap.plots.violin(shap_values, features=None, feature_names=None, max_display=None, show=True)`
+
+> Note: violin's `max_display` default resolves to 20 features (unlike waterfall/beeswarm/bar/heatmap, whose effective default is 10). The `None` above means "use the violin default", which is 20.
 
 **When to Use**:
 - Alternative to beeswarm when dataset is very large
@@ -443,18 +449,20 @@ shap.plots.bar({
 **Pattern 3: Subgroup Analysis**
 ```python
 # Define cohorts
+# .values yields a numpy boolean array; indexing an Explanation with a
+# pandas boolean Series directly raises a ValueError.
 male_mask = X_test['Sex'] == 'Male'
 female_mask = X_test['Sex'] == 'Female'
 
 # Compare cohorts
 shap.plots.bar({
-    "Male": shap_values[male_mask],
-    "Female": shap_values[female_mask]
+    "Male": shap_values[male_mask.values],
+    "Female": shap_values[female_mask.values]
 })
 
 # Separate beeswarm plots
-shap.plots.beeswarm(shap_values[male_mask])
-shap.plots.beeswarm(shap_values[female_mask])
+shap.plots.beeswarm(shap_values[male_mask.values])
+shap.plots.beeswarm(shap_values[female_mask.values])
 ```
 
 **Pattern 4: Debugging Predictions**

--- a/skills/shap/references/workflows.md
+++ b/skills/shap/references/workflows.md
@@ -12,6 +12,8 @@ Every SHAP analysis follows a general workflow:
 4. **Visualize Results**: Use plots to understand feature impacts
 5. **Interpret and Act**: Draw conclusions and make decisions
 
+> **Classifier note**: For scikit-learn classifiers (e.g. RandomForestClassifier), `explainer(X)` returns a 3D Explanation `(n_samples, n_features, n_classes)`, carrying a trailing class axis. The plotting and `.values` indexing in the workflows below assume a 2D output (XGBoost / LightGBM / gradient boosting); for forests, select a class first with `shap_values = shap_values[..., 1]` (or `shap_values[0, :, 1]` for a single sample) before plotting or computing per-feature means.
+
 ## Workflow 1: Basic Model Explanation
 
 **Use Case**: Understanding feature importance and prediction behavior for a trained model
@@ -219,9 +221,11 @@ explainer = shap.TreeExplainer(model)
 shap_values = explainer(X_test)
 
 # Step 3: Compare feature importance across groups
+# .values converts each pandas boolean Series to a numpy array;
+# indexing an Explanation with a Series directly raises a ValueError.
 groups = X_test[protected_attr].unique()
 cohorts = {
-    f"{protected_attr}={group}": shap_values[X_test[protected_attr] == group]
+    f"{protected_attr}={group}": shap_values[(X_test[protected_attr] == group).values]
     for group in groups
 }
 shap.plots.bar(cohorts)
@@ -234,7 +238,7 @@ print(f"{protected_attr} mean |SHAP|: {protected_importance:.4f}")
 # Step 5: Analyze predictions for each group
 for group in groups:
     mask = X_test[protected_attr] == group
-    group_shap = shap_values[mask]
+    group_shap = shap_values[mask.values]  # .values: Series index on an Explanation raises ValueError
 
     print(f"\n=== {protected_attr} = {group} ===")
     print(f"Sample size: {mask.sum()}")
@@ -289,11 +293,12 @@ test_subset = X_test[:50]
 shap_values = explainer.shap_values(test_subset)
 
 # Step 5: Handle multi-output models
-# For binary classification, shap_values is a list [class_0_values, class_1_values]
-# For regression, it's a single array
-if isinstance(shap_values, list):
-    # Focus on positive class
-    shap_values_positive = shap_values[1]
+# For a single input with multiple outputs, shap_values is a stacked ndarray
+# of shape (n_samples, *features, n_outputs); the class axis is the last one.
+# For regression (single output) it is a single array without that extra axis.
+if shap_values.ndim > test_subset.ndim:
+    # Focus on positive class by indexing the trailing class axis
+    shap_values_positive = shap_values[..., 1]
     shap_exp = shap.Explanation(
         values=shap_values_positive,
         base_values=explainer.expected_value[1],
@@ -460,7 +465,8 @@ for feature in lag_features:
 # Step 6: Explain specific predictions
 # E.g., why was Monday's forecast so different?
 monday_mask = X_test['DayOfWeek'] == 0
-shap.plots.waterfall(shap_values[monday_mask][0])
+# .values: indexing an Explanation with a pandas boolean Series raises a ValueError
+shap.plots.waterfall(shap_values[monday_mask.values][0])
 
 # Step 7: Validate seasonality understanding
 shap.plots.scatter(shap_values[:, 'Month'])
@@ -534,12 +540,14 @@ plt.plot(pd_result['grid_values'][0], pd_result['average'][0])
 Analyze SHAP values conditioned on other features:
 ```python
 # High Income group
+# .values yields a numpy boolean array; a pandas boolean Series index
+# on an Explanation raises a ValueError.
 high_income = X_test['Income'] > X_test['Income'].median()
-shap.plots.beeswarm(shap_values[high_income])
+shap.plots.beeswarm(shap_values[high_income.values])
 
 # Low Income group
 low_income = X_test['Income'] <= X_test['Income'].median()
-shap.plots.beeswarm(shap_values[low_income])
+shap.plots.beeswarm(shap_values[low_income.values])
 ```
 
 ### Technique 4: Feature Clustering for Redundancy


### PR DESCRIPTION
- correct the documented plot defaults (violin `max_display`, heatmap order, the scatter histogram axis).
- describe `PermutationExplainer` as an approximation, and put `max_evals` on the call rather than the constructor.
- index an `Explanation` with `mask.values` in the cohort examples; a pandas Series raises there. Also note the deprecated `LinearExplainer` argument.

Each snippet runs on shap 0.51.0.
