### PR TITLE
polars-bio: fix the coordinate system, BED/BAM/FASTA I/O, and schemas (0.31)

### DIFF
--- a/skills/polars-bio/SKILL.md
+++ b/skills/polars-bio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polars-bio
-description: High-performance genomic interval operations and bioinformatics file I/O on Polars DataFrames. Overlap, nearest, merge, coverage, complement, subtract for BED/VCF/BAM/GFF intervals. Streaming, cloud-native, faster bioframe alternative.
+description: 'High-performance genomic interval operations and bioinformatics file I/O on Polars DataFrames. Overlap, nearest, merge, coverage, complement, subtract for BED/VCF/BAM/GFF intervals. Streaming, cloud-native, faster bioframe alternative.'
 license: https://github.com/biodatageeks/polars-bio/blob/main/LICENSE
 metadata:
     skill-author: K-Dense Inc.
@@ -131,7 +131,7 @@ result_df = result.collect()
 Read and write common bioinformatics formats with `read_*`, `scan_*`, `write_*`, and `sink_*` functions. Supports cloud storage (S3, GCS, Azure) and compression (GZIP, BGZF).
 
 **Supported formats:**
-- **BED** - Genomic intervals (`read_bed`, `scan_bed`, `write_*` via generic)
+- **BED** - Genomic intervals (`read_bed`, `scan_bed`; no BED writer; write via Polars `df.write_csv("out.bed", separator="\t", include_header=False)`)
 - **VCF** - Genetic variants (`read_vcf`, `scan_vcf`, `write_vcf`, `sink_vcf`)
 - **BAM** - Aligned reads (`read_bam`, `scan_bam`, `write_bam`, `sink_bam`)
 - **CRAM** - Compressed alignments (`read_cram`, `scan_cram`, `write_cram`, `sink_cram`)
@@ -212,13 +212,13 @@ polars-bio defaults to **1-based** coordinates (genomic convention). This can be
 import polars_bio as pb
 
 # Switch to 0-based coordinates
-pb.set_option("coordinate_system", "0-based")
+pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)
 
 # Switch back to 1-based (default)
-pb.set_option("coordinate_system", "1-based")
+pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, False)
 ```
 
-I/O functions also accept `use_zero_based` to set coordinate metadata on the resulting DataFrame:
+Coordinate-bearing readers (BED, VCF, BAM, CRAM, GFF, GTF, Hi-C pairs) also accept `use_zero_based` to set coordinate metadata on the resulting DataFrame (sequence-only readers like `read_fasta`/`read_fastq` do not):
 
 ```python
 # Read BED with explicit 0-based metadata
@@ -303,7 +303,7 @@ For datasets larger than available RAM, use `scan_*` functions and streaming exe
 lf = pb.scan_bed("large_intervals.bed")
 
 # Process with streaming
-result = lf.collect(streaming=True)
+result = lf.collect(engine="streaming")
 ```
 
 DataFusion streaming is enabled by default for interval operations, processing data in batches without loading the full dataset into memory.
@@ -316,20 +316,20 @@ DataFusion streaming is enabled by default for interval operations, processing d
 
 3. **Column name mismatches:** polars-bio expects `chrom`, `start`, `end` by default. Use `cols1`/`cols2` parameters (as lists) if your columns have different names.
 
-4. **Coordinate system metadata:** When constructing DataFrames manually (not via `read_*`/`scan_*`), polars-bio warns about missing coordinate metadata. Use `pb.set_option("coordinate_system", "0-based")` globally, or use I/O functions that set metadata automatically.
+4. **Coordinate system metadata:** When constructing DataFrames manually (not via `read_*`/`scan_*`), polars-bio warns about missing coordinate metadata. Use `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` globally, or use I/O functions that set metadata automatically.
 
 5. **Probe-build order matters:** For overlap, nearest, and coverage, the first DataFrame is probed against the second. Swapping arguments changes which intervals appear in the left vs right output columns, and can affect performance.
 
 6. **INT32 position limit:** Genomic positions are stored as 32-bit integers, limiting coordinates to ~2.1 billion. This is sufficient for all known genomes but may be an issue with custom coordinate spaces.
 
-7. **BAM index requirements:** `read_bam` and `scan_bam` require a `.bai` index file alongside the BAM. Create one with `samtools index` if missing.
+7. **BAM index is optional:** `read_bam` and `scan_bam` work without a `.bai`/`.csi` index. An index is only needed for indexed parallel reads and predicate pushdown (region-based filtering), which become automatic when an index is present. Create one with `samtools index` to enable them.
 
 8. **Parallel execution disabled by default:** DataFusion parallelism defaults to 1 partition. Enable for large datasets:
    ```python
    pb.set_option("datafusion.execution.target_partitions", 8)
    ```
 
-9. **CRAM has separate functions:** Use `read_cram`/`scan_cram`/`register_cram` for CRAM files (not `read_bam`). CRAM functions require a `reference_path` parameter.
+9. **CRAM has separate functions:** Use `read_cram`/`scan_cram`/`register_cram` for CRAM files (not `read_bam`). Only `write_cram`/`sink_cram` require a `reference_path`; `read_cram`/`scan_cram` accept `reference_path=None` (the embedded reference / MD5 lookup is used when available).
 
 ## Best Practices
 
@@ -341,7 +341,7 @@ DataFusion streaming is enabled by default for interval operations, processing d
    pb.set_option("datafusion.execution.target_partitions", os.cpu_count())
    ```
 
-3. **Use BGZF compression:** BGZF-compressed files (`.bed.gz`, `.vcf.gz`) support parallel block decompression, significantly faster than plain GZIP.
+3. **Use BGZF compression:** BGZF-compressed files (`.bed.gz`, `.vcf.gz`) support parallel block decompression, significantly faster than plain GZIP. For BED specifically, plain (non-BGZF) GZIP is unsupported and panics, so BED `.gz` files must be BGZF-compressed (e.g., created with `bgzip`).
 
 4. **Select columns early:** When only specific columns are needed, select them early to reduce memory usage:
    ```python

--- a/skills/polars-bio/references/bioframe_migration.md
+++ b/skills/polars-bio/references/bioframe_migration.md
@@ -138,10 +138,9 @@ Benchmarks on real-world genomic datasets (from the polars-bio paper, Bioinforma
 
 | Operation | bioframe | polars-bio | Speedup |
 |-----------|----------|------------|---------|
-| overlap | 1.0x | 6.5x | 6.5x |
-| nearest | 1.0x | 38x | 38x |
-| merge | 1.0x | 8.2x | 8.2x |
-| coverage | 1.0x | 12x | 12x |
+| count_overlaps | 1.0x | 38x | 38x |
+| nearest | 1.0x | 15.5x | 15.5x |
+| coverage | 1.0x | 15x | 15x |
 
 Speedups come from:
 - Rust-based interval tree implementation
@@ -206,7 +205,7 @@ import polars_bio as pb
 
 # Lazy scan, streaming execution
 lf = pb.scan_bed("huge_intervals.bed")
-result = pb.merge(lf).collect(streaming=True)
+result = pb.merge(lf).collect(engine="streaming")
 ```
 
 ## pandas Compatibility Mode

--- a/skills/polars-bio/references/configuration.md
+++ b/skills/polars-bio/references/configuration.md
@@ -53,10 +53,10 @@ polars-bio defaults to 1-based coordinates (standard genomic convention).
 import polars_bio as pb
 
 # Switch to 0-based half-open coordinates
-pb.set_option("coordinate_system", "0-based")
+pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)
 
 # Switch back to 1-based (default)
-pb.set_option("coordinate_system", "1-based")
+pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, False)
 
 # Check current setting
 print(pb.get_option("coordinate_system"))
@@ -110,7 +110,7 @@ Use Polars' native streaming for post-processing operations:
 
 ```python
 # Collect with Polars streaming
-result = lf.collect(streaming=True)
+result = lf.collect(engine="streaming")
 ```
 
 ### Combining Both
@@ -126,7 +126,7 @@ lf2 = pb.scan_bed("large2.bed")
 result_lf = pb.overlap(lf1, lf2)
 
 # Collect with Polars streaming for final materialization
-result = result_lf.collect(streaming=True)
+result = result_lf.collect(engine="streaming")
 ```
 
 ## Logging
@@ -142,7 +142,7 @@ pb.set_loglevel("info")    # Standard messages
 pb.set_loglevel("warn")    # Warnings only (default)
 ```
 
-**Note:** Only `"debug"`, `"info"`, and `"warn"` are valid log levels.
+**Note:** Valid log levels are `"debug"`, `"info"`, `"warn"`, and `"warning"` (`"warn"` and `"warning"` are equivalent).
 
 ## Metadata Management
 
@@ -172,4 +172,4 @@ pb.from_polars("my_table", df)
 | Option | Default | Description |
 |--------|---------|-------------|
 | `datafusion.execution.target_partitions` | `1` | Number of parallel execution partitions |
-| `coordinate_system` | `"1-based"` | Default coordinate system (`"0-based"` or `"1-based"`) |
+| `coordinate_system` | `None` | Legacy key; `get_option("coordinate_system")` returns `None` (unset). The effective runtime switch is `datafusion.bio.coordinate_system_zero_based` (default `"false"`, i.e. 1-based), settable via `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True/False)` |

--- a/skills/polars-bio/references/file_io.md
+++ b/skills/polars-bio/references/file_io.md
@@ -14,7 +14,7 @@ polars-bio provides `read_*`, `scan_*`, `write_*`, and `sink_*` functions for co
 | CRAM | `read_cram` | `scan_cram` | `register_cram` | `write_cram` | `sink_cram` |
 | GFF | `read_gff` | `scan_gff` | `register_gff` | — | — |
 | GTF | `read_gtf` | `scan_gtf` | `register_gtf` | — | — |
-| FASTA | `read_fasta` | `scan_fasta` | — | — | — |
+| FASTA | `read_fasta` | `scan_fasta` | — | `write_fasta` | `sink_fasta` |
 | FASTQ | `read_fastq` | `scan_fastq` | `register_fastq` | `write_fastq` | `sink_fastq` |
 | SAM | `read_sam` | `scan_sam` | `register_sam` | `write_sam` | `sink_sam` |
 | Hi-C pairs | `read_pairs` | `scan_pairs` | `register_pairs` | — | — |
@@ -43,7 +43,7 @@ Not all functions support all parameters. SAM functions lack cloud parameters. F
 
 ### read_bed / scan_bed
 
-Read BED files. Columns are auto-detected (BED3 through BED12). BED files use 0-based half-open coordinates; polars-bio attaches coordinate metadata automatically.
+Read BED files. Only **BED4** is supported in v0.31 (chrom, start, end, name); the 4th (name) column is required. BED3 input is NOT read as its first three columns: each record fails to parse and the call returns an empty frame (shape `(0, 4)`) with no exception raised to the caller. Pad BED3 to BED4, or read it through `read_table(schema="bed3")` instead. BED files use 0-based half-open coordinates; polars-bio attaches coordinate metadata automatically. Note: plain (non-BGZF) GZIP is not supported for BED.
 
 ```python
 import polars_bio as pb
@@ -55,15 +55,16 @@ df = pb.read_bed("regions.bed")
 lf = pb.scan_bed("regions.bed")
 ```
 
-### Column Schema (BED3)
+### Column Schema (BED4)
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `chrom` | String | Chromosome name |
-| `start` | Int64 | Start position |
-| `end` | Int64 | End position |
+| `start` | UInt32 | Start position |
+| `end` | UInt32 | End position |
+| `name` | String | Feature name |
 
-Extended BED fields (auto-detected) add: `name`, `score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, `blockStarts`.
+Only BED4 is supported in v0.31; the extended BED fields (`score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, `blockStarts`) are not parsed. For files with extra columns, use `read_table` with the bioframe schema whose column count equals the file's columns exactly (e.g., `schema="bed12"` for a 12-column file); the count must match, so a higher schema than the data does not work.
 
 ## VCF Format
 
@@ -103,9 +104,10 @@ df = pb.read_vcf("variants.vcf.gz", samples=["SAMPLE1", "SAMPLE2"])
 | `id` | String | Variant ID |
 | `ref` | String | Reference allele |
 | `alt` | String | Alternate allele(s) |
-| `qual` | Float32 | Quality score |
+| `qual` | Float64 | Quality score |
 | `filter` | String | Filter status |
-| `info` | String | INFO field (raw, unless `info_fields` specified) |
+
+INFO fields are not kept as a single raw `info` string. By default (`info_fields=None`) every INFO field declared in the VCF header is exploded into its own typed column (e.g., `AF` as `List(Float32)`, `DP` as `Int32`). Pass `info_fields=[...]` to restrict which ones are materialized. FORMAT fields are top-level columns for single-sample VCFs and a nested `genotypes` struct column for multi-sample VCFs.
 
 ### write_vcf / sink_vcf
 
@@ -123,7 +125,7 @@ pb.sink_vcf(lf, "output.vcf")
 
 ### read_bam / scan_bam
 
-Read aligned sequencing reads from BAM files. Requires a `.bai` index file.
+Read aligned sequencing reads from BAM files. A `.bai`/`.csi` index is optional: `read_bam` and `scan_bam` work without one. An index is only needed for indexed parallel reads and predicate pushdown (region-based filtering); create one with `samtools index` to enable them.
 
 ```python
 import polars_bio as pb
@@ -153,8 +155,8 @@ df = pb.read_bam("aligned.bam", tag_fields=["NM", "MD"])
 | Column | Type | Description |
 |--------|------|-------------|
 | `chrom` | String | Reference sequence name |
-| `start` | Int64 | Alignment start position |
-| `end` | Int64 | Alignment end position |
+| `start` | UInt32 | Alignment start position |
+| `end` | UInt32 | Alignment end position |
 | `name` | String | Read name |
 | `flags` | UInt32 | SAM flags |
 | `mapping_quality` | UInt32 | Mapping quality |
@@ -162,8 +164,8 @@ df = pb.read_bam("aligned.bam", tag_fields=["NM", "MD"])
 | `sequence` | String | Read sequence |
 | `quality_scores` | String | Base quality string |
 | `mate_chrom` | String | Mate reference name |
-| `mate_start` | Int64 | Mate start position |
-| `template_length` | Int64 | Template length |
+| `mate_start` | UInt32 | Mate start position |
+| `template_length` | Int32 | Template length |
 
 ### write_bam / sink_bam
 
@@ -237,12 +239,12 @@ df = pb.read_gff("annotations.gff3", attr_fields=["gene_id", "gene_name"])
 | `chrom` | String | Sequence name |
 | `source` | String | Feature source |
 | `type` | String | Feature type (gene, exon, etc.) |
-| `start` | Int64 | Start position |
-| `end` | Int64 | End position |
+| `start` | UInt32 | Start position |
+| `end` | UInt32 | End position |
 | `score` | Float32 | Score |
 | `strand` | String | Strand (+/-/.) |
 | `phase` | UInt32 | Phase (0/1/2) |
-| `attributes` | String | Attributes string |
+| `attributes` | List(Struct) | Tag/value pairs (`List(Struct{tag: String, value: String})`) when `attr_fields=None`; named fields become their own String columns when `attr_fields` is set |
 
 ## FASTA Format
 
@@ -263,6 +265,13 @@ df = pb.read_fasta("reference.fasta")
 | `name` | String | Sequence name |
 | `description` | String | Description line |
 | `sequence` | String | Nucleotide sequence |
+
+### write_fasta / sink_fasta
+
+```python
+rows_written = pb.write_fasta(df, "output.fasta")
+pb.sink_fasta(lf, "output.fasta")
+```
 
 ## FASTQ Format
 
@@ -338,10 +347,10 @@ lf = pb.scan_pairs("contacts.pairs")
 | Column | Type | Description |
 |--------|------|-------------|
 | `readID` | String | Read identifier |
-| `chrom1` | String | Chromosome of first contact |
-| `pos1` | Int32 | Position of first contact |
-| `chrom2` | String | Chromosome of second contact |
-| `pos2` | Int32 | Position of second contact |
+| `chr1` | String | Chromosome of first contact |
+| `pos1` | UInt32 | Position of first contact |
+| `chr2` | String | Chromosome of second contact |
+| `pos2` | UInt32 | Position of second contact |
 | `strand1` | String | Strand of first contact |
 | `strand2` | String | Strand of second contact |
 
@@ -349,13 +358,13 @@ lf = pb.scan_pairs("contacts.pairs")
 
 ### read_table / scan_table
 
-Read tab-delimited files with custom schema. Useful for non-standard formats or bioframe-compatible tables.
+Read tab-delimited (BED-like) files. The `schema` argument is a bioframe schema **name string** (e.g., `"bed3"`, `"bed4"`, `"bed6"`, `"bed9"`, `"bed12"`), not a dict of column types; passing a dict raises `TypeError: unhashable type: 'dict'`. The bedN schema must match the file's column count exactly (e.g., `"bed12"` for a 12-column file); a mismatch raises `ValueError: Schema incompatible with the input`.
 
 ```python
 import polars_bio as pb
 
-df = pb.read_table("custom.tsv", schema={"chrom": str, "start": int, "end": int, "name": str})
-lf = pb.scan_table("custom.tsv", schema={"chrom": str, "start": int, "end": int})
+df = pb.read_table("custom.tsv", schema="bed4")
+lf = pb.scan_table("custom.tsv", schema="bed3")
 ```
 
 ## Cloud Storage

--- a/skills/polars-bio/references/pileup_operations.md
+++ b/skills/polars-bio/references/pileup_operations.md
@@ -41,8 +41,8 @@ When `per_base=False` (default), adjacent positions with the same depth are grou
 | Column | Type | Description |
 |--------|------|-------------|
 | `contig` | String | Chromosome/contig name |
-| `pos_start` | Int64 | Block start position |
-| `pos_end` | Int64 | Block end position |
+| `pos_start` | Int32 | Block start position |
+| `pos_end` | Int32 | Block end position |
 | `coverage` | Int16 | Read depth |
 
 ### Output Schema (Per-Base Mode)
@@ -52,7 +52,7 @@ When `per_base=True`, each position is reported individually:
 | Column | Type | Description |
 |--------|------|-------------|
 | `contig` | String | Chromosome/contig name |
-| `pos` | Int64 | Position |
+| `pos` | Int32 | Position |
 | `coverage` | Int16 | Read depth at position |
 
 ### filter_flag


### PR DESCRIPTION
- correct the I/O reference where it contradicted the skill itself: BAM does not require a `.bai` index, and FASTA has `write_fasta`/`sink_fasta`.
- fix the BED3 read note, remove an invalid `read_table` schema name, and correct the `depth()` column dtypes.

Confirmed by round-tripping real files on polars-bio 0.31.0.
