### PR TITLE
optimize-for-gpu: fix GPU API examples and the betweenness benchmark

### DIFF
--- a/skills/optimize-for-gpu/SKILL.md
+++ b/skills/optimize-for-gpu/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-for-gpu
-description: "GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested."
+description: 'GPU-accelerate Python code using CuPy, Numba CUDA, Warp, cuDF, cuML, cuGraph, KvikIO, cuCIM, cuxfilter, cuVS, cuSpatial, and RAFT. Use whenever the user mentions GPU/CUDA/NVIDIA acceleration, or wants to speed up NumPy, pandas, scikit-learn, scikit-image, NetworkX, GeoPandas, or Faiss workloads. Covers physics simulation, differentiable rendering, mesh ray casting, particle systems (DEM/SPH/fluids), vector/similarity search, GPUDirect Storage file IO, interactive dashboards, geospatial analysis, medical imaging, and sparse eigensolvers. Also use when you see CPU-bound Python code (loops, large arrays, ML pipelines, graph analytics, image processing) that would benefit from GPU acceleration, even if not explicitly requested.'
 metadata:
   author: K-Dense, Inc.
 ---
@@ -77,7 +77,7 @@ Use Warp when the user's code is primarily:
 - Any Python simulation loop that needs to be JIT-compiled to GPU
 - Spatial computing with meshes, volumes (NanoVDB), hash grids, or BVH queries
 
-Warp JIT-compiles `@wp.kernel` Python functions to CUDA, with built-in types for spatial computing (vec3, mat33, quat, transform) and primitives for geometry queries (Mesh, Volume, HashGrid, BVH). All kernels are automatically differentiable.
+Warp JIT-compiles `@wp.kernel` Python functions to CUDA, with built-in types for spatial computing (vec3, mat33, quat, transform) and primitives for geometry queries (Mesh, Volume, HashGrid, BVH). Kernels recorded on a `wp.Tape` are automatically differentiable (in-place writes are not differentiable).
 
 **Best for:** Physics simulation, mesh ray casting, particle systems, differentiable rendering, robotics kinematics, SDF operations, any workload combining spatial data structures with GPU compute.
 
@@ -380,7 +380,7 @@ GPU is a poor fit when:
 2. **Minimize host-device transfers.** Keep data on GPU. Every transfer across PCI-e is expensive (~12 GB/s) vs GPU memory bandwidth (~900 GB/s+).
 3. **Batch operations.** Fewer large GPU operations beat many small ones.
 4. **Only write custom kernels if needed.** CuPy and cuDF use NVIDIA's hand-tuned libraries. Custom Numba kernels should be reserved for operations that don't have library equivalents.
-5. **Profile the GPU version.** Use `nvprof`, `nsys`, or CuPy's built-in benchmarking.
+5. **Profile the GPU version.** Use `nsys` or `ncu`, or `cupyx.profiler.benchmark`.
 
 ### 4. Memory Management Principles
 These apply across all libraries:
@@ -625,10 +625,7 @@ import cudf
 
 points_cu = cuspatial.from_geopandas(points)
 polygons_cu = cuspatial.from_geopandas(polygons)
-joined = cuspatial.point_in_polygon(
-    points_cu.geometry.x, points_cu.geometry.y,
-    polygons_cu.geometry
-)
+joined = cuspatial.point_in_polygon(points_cu.geometry, polygons_cu.geometry)
 ```
 
 ### Faiss/Annoy to cuVS

--- a/skills/optimize-for-gpu/references/cugraph.md
+++ b/skills/optimize-for-gpu/references/cugraph.md
@@ -3,7 +3,7 @@
 cuGraph is NVIDIA's GPU-accelerated graph analytics library within the RAPIDS ecosystem. It provides NetworkX-compatible APIs for graph algorithms, delivering 10-500x+ speedup over CPU-based NetworkX on medium to large graphs. It supports both a direct Python API and a **zero-code-change NetworkX backend** (nx-cugraph) that accelerates existing NetworkX code with no modifications.
 
 > **Full documentation:** https://docs.rapids.ai/api/cugraph/stable/
-> **Version (stable):** 26.02.00
+> **Version (stable):** 26.04.00
 > **Repository:** https://github.com/rapidsai/cugraph
 
 ## Table of Contents
@@ -700,7 +700,7 @@ edges = cudf.from_pandas(df)
 G = cugraph.Graph()
 G.from_cudf_edgelist(edges, source="src", destination="dst")
 pr = cugraph.pagerank(G, alpha=0.85)
-bc = cugraph.betweenness_centrality(G)
+bc = cugraph.betweenness_centrality(G, k=100)  # sampled over k vertices (matches the benchmark); omit k for exact
 parts, modularity = cugraph.louvain(G, resolution=1.0)
 ```
 

--- a/skills/optimize-for-gpu/references/cuml.md
+++ b/skills/optimize-for-gpu/references/cuml.md
@@ -413,7 +413,7 @@ from cuml.fil import ForestInference
 fil_model = ForestInference.load("xgboost_model.ubj", is_classifier=True)
 
 # Optional: optimize for specific batch size
-fil_model.optimize()
+fil_model.optimize(batch_size=1_000_000)
 
 # Predict (80x+ faster than sklearn)
 predictions = fil_model.predict(X_test)

--- a/skills/optimize-for-gpu/references/cupy.md
+++ b/skills/optimize-for-gpu/references/cupy.md
@@ -478,7 +478,7 @@ print(result)  # Shows CPU and GPU elapsed times with statistics
 
 In IPython/Jupyter:
 ```python
-%load_ext cupy
+%load_ext cupyx.profiler
 %gpu_timeit my_function(args)
 ```
 

--- a/skills/optimize-for-gpu/references/cuxfilter.md
+++ b/skills/optimize-for-gpu/references/cuxfilter.md
@@ -3,7 +3,7 @@
 cuxfilter is a GPU-accelerated cross-filtering dashboard library from the NVIDIA RAPIDS ecosystem. It enables interactive, multi-chart exploratory data analysis dashboards from Jupyter notebooks in just a few lines of Python. All filtering, groupby, and aggregation operations happen on the GPU via cuDF, with only the visualization results sent to the browser.
 
 > **Full documentation:** https://docs.rapids.ai/api/cuxfilter/stable/
-> **Version (stable):** 26.02.00
+> **Version (stable):** 26.04.00
 > **Repository:** https://github.com/rapidsai/cuxfilter
 
 ## Table of Contents
@@ -92,7 +92,7 @@ import cugraph
 
 edges = cudf.DataFrame({"source": [0, 1, 2], "target": [1, 2, 3], "weight": [1.0, 2.0, 3.0]})
 G = cugraph.Graph()
-G.from_cudf_edgelist(edges, destination="target")
+G.from_cudf_edgelist(edges, destination="target", edge_attr="weight")
 cux_df = cuxfilter.DataFrame.load_graph((G.nodes(), G.edges()))
 ```
 

--- a/skills/optimize-for-gpu/references/numba.md
+++ b/skills/optimize-for-gpu/references/numba.md
@@ -37,7 +37,7 @@ uv add numba numba-cuda
 
 The `numba-cuda` package is the actively maintained NVIDIA implementation. It implements functionality under the `numba.cuda` namespace — no code changes needed vs the old built-in target.
 
-**Requirements:** CUDA Toolkit >= 11.2, GPU with Compute Capability >= 5.0 (Maxwell or newer).
+**Requirements:** CUDA Toolkit >= 11.2, GPU with Compute Capability >= 3.5 (>= 5.0 recommended).
 
 ```python
 from numba import cuda
@@ -382,7 +382,7 @@ For operations on sub-arrays (not just scalars). Uses NumPy's generalized ufunc 
 ```python
 from numba import guvectorize, float32
 
-@guvectorize([float32[:,:], float32[:,:], float32[:,:]],
+@guvectorize([(float32[:,:], float32[:,:], float32[:,:])],
              '(m,n),(n,p)->(m,p)', target='cuda')
 def gpu_matmul(A, B, C):
     for i in range(A.shape[0]):

--- a/skills/optimize-for-gpu/references/warp.md
+++ b/skills/optimize-for-gpu/references/warp.md
@@ -372,7 +372,7 @@ grad_a = tape.gradients[a]
 ```
 
 Key features:
-- Automatic adjoint code generation for all kernels
+- Automatic adjoint code generation for kernels recorded on a `wp.Tape` (in-place writes are not differentiable)
 - `wp.Tape` records and replays computation graphs
 - Integrates with PyTorch autograd and JAX JIT
 - Custom gradient functions via `@wp.func_grad`


### PR DESCRIPTION
- correct the GPU API usage in the examples, and pass `batch_size` to the FIL `optimize()` call its own comment describes.
- match the cugraph betweenness-centrality migration example to its benchmark (`k=100`).

GPU libraries do not install on the dev machine, so the API names were checked against current vendor docs. The performance figures are the author's own approximations and stay untouched.
