### PR TITLE
latex-posters: fix templates that did not compile, themes, and the review script

### DIFF
--- a/skills/latex-posters/SKILL.md
+++ b/skills/latex-posters/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: latex-posters
-description: "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication."
+description: 'Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication.'
 allowed-tools: Read Write Edit Bash
 ---
 
@@ -22,17 +22,35 @@ This skill should be used when:
 - Building posters with complex multi-column layouts
 - Integrating figures, tables, equations, and citations in poster format
 
-## AI-Powered Visual Element Generation
+## Toolchain and Prerequisites
 
-**STANDARD WORKFLOW: Generate ALL major visual elements using AI before creating the LaTeX poster.**
+**Primary (pure-LaTeX) path, works out of the box with a TeX Live install:**
+1. Install the LaTeX poster packages (see [Package Installation](#package-installation)).
+2. Start from one of the bundled templates in `assets/` (`tikzposter_template.tex`, `beamerposter_template.tex`, `baposter_template.tex`).
+3. Build figures with native LaTeX tooling: TikZ/PGF diagrams, `pgfplots` charts, and `\includegraphics` for externally produced graphics.
+4. Compile with `pdflatex` (or `xelatex`/`lualatex` for system fonts), then run `scripts/review_poster.sh` for QA.
 
-This is the recommended approach for creating visually compelling posters:
+This pure-LaTeX path is the documented happy path and the rest of this guide assumes it unless stated otherwise.
+
+**Optional AI image-generation path (extra prerequisites, not required):**
+The bundled `scripts/generate_schematic.py` (and its engine `scripts/generate_schematic_ai.py`) can generate raster visuals via the OpenRouter API. This path is OPTIONAL and has prerequisites the pure-LaTeX path does not:
+- A **paid** `OPENROUTER_API_KEY` (set as an environment variable). Image-model calls are billed per request.
+- Python with the `requests` library installed.
+- **Network egress** to `https://openrouter.ai` (the scripts send your prompts, and review prompts include the generated image, to that third-party API).
+
+If you do not have these, skip the AI section entirely; everything below works with LaTeX alone.
+
+## AI-Powered Visual Element Generation (Optional)
+
+**OPTIONAL WORKFLOW: when the OpenRouter prerequisites above are met, you may generate major visual elements with AI before assembling the LaTeX poster.**
+
+This is one optional approach for creating visually rich posters; it is not required and is not the default:
 1. Plan all visual elements needed (title, intro, methods, results, conclusions)
-2. Generate each element using scientific-schematics or Nano Banana Pro
+2. Generate each element with the bundled `scripts/generate_schematic.py`. (`scientific-schematics` and Nano Banana image generation are optional external skills and are NOT bundled in this repo; the bundled script is the concrete in-repo alternative.)
 3. Assemble generated images in the LaTeX template
 4. Add text content around the visuals
 
-**Target: 60-70% of poster area should be AI-generated visuals, 30-40% text.**
+**When using this optional path, aim for roughly 60-70% of poster area as AI-generated visuals, 30-40% text.** (For a pure-LaTeX poster, balance visuals and text using the design guidance later in this document.)
 
 ---
 
@@ -305,7 +323,7 @@ After passing the pre-generation review, identify visual elements needed:
 
 Use the appropriate tool for each element type:
 
-**For Schematics and Diagrams (scientific-schematics):**
+**For Schematics and Diagrams (bundled `generate_schematic.py`; the external `scientific-schematics` skill is optional and not bundled):**
 ```bash
 # Create figures directory
 mkdir -p figures
@@ -331,7 +349,7 @@ python scripts/generate_schematic.py "POSTER FORMAT for A0. ONE case study: Larg
 # If you need 3 cases → make 3 separate simple graphics (not one complex graphic)
 ```
 
-**For Stylized Blocks and Graphics (Nano Banana Pro):**
+**For Stylized Blocks and Graphics (bundled `generate_schematic.py`; the external Nano Banana image skill is optional and not bundled):**
 ```bash
 # Title block - SIMPLE
 python scripts/generate_schematic.py "POSTER FORMAT for A0. Title block: 'ML FOR DRUG DISCOVERY' in HUGE bold text (120pt+). Dark blue background. ONE subtle icon. NO other text. 40% white space. Readable from 15 feet." -o figures/title_block.png
@@ -385,6 +403,8 @@ python scripts/generate_schematic.py "POSTER FORMAT for A0. SIMPLE bar chart wit
 ### Step 3: Assemble in LaTeX Template
 
 After all figures pass the post-generation review, include them in your poster template:
+
+**Resolution note (raster AI output vs print):** AI image generation returns raster PNGs, while the design section requires 300 DPI for large-format print. At 300 DPI, an A0 sheet (841 x 1189 mm) is roughly 9933 x 14043 px, far beyond typical AI output. Treat AI rasters as suitable for on-screen/digital posters or as small accent elements only. For printed A0 posters, keep core diagrams as vector graphics (native TikZ/PGF or vector PDF), or generate AI rasters large enough that each placed image still resolves to >=150-300 DPI at its final printed size, and verify with the image-resolution check below before printing.
 
 **tikzposter example:**
 ```latex
@@ -555,14 +575,14 @@ grep "Overfull" poster.log
 
 ---
 
-## Scientific Schematics Integration
+## Scientific Schematics Integration (Optional)
 
-For detailed guidance on creating schematics, refer to the **scientific-schematics** skill documentation.
+The bundled `scripts/generate_schematic.py` is the in-repo tool for AI-generated schematics (requires the OpenRouter prerequisites listed above). A separate `scientific-schematics` skill is an optional external add-on and is NOT bundled in this repo; if you do not have it, use the bundled script or build diagrams directly in TikZ/PGF.
 
-**Key capabilities:**
-- Nano Banana Pro automatically generates, reviews, and refines diagrams
-- Creates publication-quality images with proper formatting
-- Ensures accessibility (colorblind-friendly, high contrast)
+**Key capabilities of the bundled AI script:**
+- Generates, reviews, and iteratively refines diagrams via the OpenRouter API
+- Produces raster images intended for layout (see resolution note under the assembly steps)
+- Prompt templates encourage accessible output (colorblind-friendly, high contrast)
 - Supports iterative refinement for complex diagrams
 
 ---
@@ -729,8 +749,12 @@ Provide professional color palettes for various contexts:
 
 **beamerposter**:
 ```latex
-\usetheme{Berlin}
+% Plain default theme (Berlin is a presentation navigation theme: it adds a
+% miniframes headline bar that is useless on a poster).
+\usetheme{default}
 \usecolortheme{beaver}
+\setbeamertemplate{headline}{}
+\setbeamertemplate{footline}{}
 ```
 
 **tikzposter**:
@@ -834,8 +858,9 @@ Posters should use the entire page without excessive margins. Configure packages
 % Remove default beamer margins
 \setbeamersize{text margin left=0mm, text margin right=0mm}
 
-% Use geometry for precise control
-\usepackage[margin=10mm]{geometry}  % 10mm margins all around
+% Use geometry for precise control (beamerposter already loads geometry,
+% so set margins with \geometry, not a second \usepackage)
+\geometry{margin=10mm}  % 10mm margins all around
 
 % Remove navigation symbols
 \setbeamertemplate{navigation symbols}{}
@@ -863,7 +888,7 @@ Posters should use the entire page without excessive margins. Configure packages
 
 **baposter - Full Page Setup**:
 ```latex
-\documentclass[a0paper,portrait,fontscale=0.285]{baposter}
+\documentclass[a0paper,portrait,fontscale=0.285]{xebaposter}
 
 \begin{poster}{
   grid=false,
@@ -893,7 +918,7 @@ Posters should use the entire page without excessive margins. Configure packages
 \documentclass[..., margin=5mm, innermargin=10mm]{tikzposter}
 
 % Fix for baposter - adjust in document class
-\documentclass[a0paper, margin=5mm]{baposter}
+\documentclass[a0paper, margin=5mm]{xebaposter}
 ```
 
 **Problem**: Content doesn't fill vertical space
@@ -1100,8 +1125,12 @@ Open PDF at 100% zoom and check:
 pdffonts poster.pdf
 
 # All fonts should show "yes" in "emb" column
-# If any show "no", recompile with:
-pdflatex -dEmbedAllFonts=true poster.tex
+# pdfLaTeX already embeds fonts by default, so a normal recompile usually fixes "no":
+pdflatex poster.tex
+# For guaranteed embedding (e.g. fonts pulled from included graphics), post-process
+# with Ghostscript (this is where -dEmbedAllFonts belongs), or use xelatex/lualatex:
+# gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dEmbedAllFonts=true -dSubsetFonts=true \
+#    -sOutputFile=poster-embedded.pdf poster.pdf
 ```
 
 **Image Resolution Check**:
@@ -1258,13 +1287,13 @@ echo "- Proofreading for typos"
 | Large white margins | Incorrect margin settings | Reduce margin in documentclass |
 | Content cut off | Exceeds page boundaries | Check total width/height calculations |
 | Blurry images | Low resolution (<300 DPI) | Replace with higher resolution images |
-| Missing fonts | Fonts not embedded | Compile with -dEmbedAllFonts=true |
+| Missing fonts | Fonts not embedded | pdfLaTeX embeds by default; recompile, or force-embed with Ghostscript (`gs ... -dEmbedAllFonts=true`) or xelatex/lualatex |
 | Wrong page size | Incorrect paper size setting | Verify documentclass paper size |
 | Colors look wrong | RGB vs CMYK mismatch | Convert color space for print |
 | File too large (>50MB) | Uncompressed images | Optimize images or compress PDF |
 | QR codes don't work | Too small or low resolution | Minimum 2×2cm, high contrast |
 
-### 11. Common Poster Content Patterns
+### 12. Common Poster Content Patterns
 
 Effective content organization for different research types:
 
@@ -1297,7 +1326,7 @@ Effective content organization for different research types:
 7. Conclusions: Summary and implications
 8. References
 
-### 12. Accessibility and Inclusive Design
+### 13. Accessibility and Inclusive Design
 
 Design posters that are accessible to diverse audiences:
 
@@ -1319,7 +1348,7 @@ Design posters that are accessible to diverse audiences:
 - International audience considerations
 - Consider multilingual QR code options for global conferences
 
-### 13. Poster Presentation Best Practices
+### 14. Poster Presentation Best Practices
 
 Guidance beyond LaTeX for effective poster sessions:
 
@@ -1489,13 +1518,13 @@ Guidance beyond LaTeX for effective poster sessions:
 ## Integration with Other Skills
 
 This skill works effectively with:
-- **Scientific Schematics**: CRITICAL - Use for generating all poster diagrams and flowcharts
-- **Generate Image / Nano Banana Pro**: For stylized graphics, conceptual illustrations, and summary visuals
+- **Bundled `generate_schematic.py`**: Optional AI generation of poster diagrams and flowcharts (requires a paid OpenRouter key, see prerequisites).
+- **`scientific-schematics` / image-generation skills (e.g. Nano Banana)**: Optional external skills, NOT bundled in this repo; use them only if separately installed, otherwise rely on the bundled script or native TikZ/PGF.
 - **Scientific Writing**: For developing poster content from papers
 - **Literature Review**: For contextualizing research
 - **Data Analysis**: For creating result figures and charts
 
-**Recommended workflow**: Always use scientific-schematics and generate-image skills BEFORE creating the LaTeX poster to generate all visual elements.
+**Recommended workflow**: Build the poster with pure LaTeX as the default. Optionally, if the OpenRouter prerequisites are met, generate visual elements with the bundled `generate_schematic.py` (or an external image skill, if you have one) BEFORE assembling the LaTeX poster.
 
 ## Common Pitfalls to Avoid
 
@@ -1555,21 +1584,28 @@ Ensure required LaTeX packages are installed:
 
 ```bash
 # For TeX Live (Linux/Mac)
-tlmgr install beamerposter tikzposter baposter
+# Note: current TeX Live ships "xebaposter" (a TikZ-based baposter successor),
+# not the original "baposter" class. Use xebaposter; its \headerbox/\begin{poster}
+# syntax is backward-compatible, so the bundled baposter template compiles against it.
+tlmgr install beamerposter tikzposter xebaposter
 
 # For MiKTeX (Windows)
 # Packages typically auto-install on first use
 
 # Additional recommended packages
 tlmgr install qrcode graphics xcolor tcolorbox subcaption
+
+# If you specifically need the original baposter.cls (not in TeX Live), install it
+# manually from CTAN (https://ctan.org/pkg/baposter) into your local texmf tree.
 ```
 
 ## Scripts and Automation
 
 Helper scripts available in `scripts/` directory:
 
-- `review_poster.sh`: Poster review and validation
-- `generate_schematic.py`: Generate scientific diagrams and schematics
+- `review_poster.sh`: Poster review and validation (pure-LaTeX QA, no external services).
+- `generate_schematic.py`: Thin CLI wrapper for the optional AI image path. Validates the `OPENROUTER_API_KEY` and delegates to `generate_schematic_ai.py`.
+- `generate_schematic_ai.py`: The actual generation engine (OpenRouter API calls, iterative quality review). Requires a paid `OPENROUTER_API_KEY`, the `requests` library, and network access to openrouter.ai. Optional; not needed for the pure-LaTeX workflow.
 
 ## References
 
@@ -1584,11 +1620,10 @@ Comprehensive reference files for detailed guidance:
 
 Ready-to-use poster templates in `assets/` directory:
 
-- beamerposter templates (classic, modern, colorful)
-- tikzposter templates (default, rays, wave, envelope)
-- baposter templates (portrait, landscape, minimal)
-- Example posters from various scientific disciplines
-- Color scheme definitions and institutional templates
+- `tikzposter_template.tex` - tikzposter starting point
+- `beamerposter_template.tex` - beamerposter starting point
+- `baposter_template.tex` - box-based template (compiles against xebaposter; see Package Installation)
+- `poster_quality_checklist.md` - pre-print QA checklist
 
-Load these templates and customize for your specific research and conference requirements.
+Load a template and customize it for your specific research and conference requirements.
 

--- a/skills/latex-posters/assets/baposter_template.tex
+++ b/skills/latex-posters/assets/baposter_template.tex
@@ -5,7 +5,10 @@
 % Excellent for multi-column layouts with automatic positioning
 % ==============================================================================
 
-\documentclass[a0paper,portrait,fontscale=0.285]{baposter}
+% Current TeX Live ships xebaposter (a backward-compatible baposter successor),
+% not the original "baposter" class. Compile with pdflatex, xelatex, or lualatex.
+% If you have the original baposter.cls installed, you may change this back to {baposter}.
+\documentclass[a0paper,portrait,fontscale=0.285]{xebaposter}
 
 % Packages
 \usepackage{graphicx}
@@ -25,25 +28,24 @@
 
 \begin{document}
 
+% Note: do not leave blank lines inside this option block. xebaposter parses
+% the options as a single argument, and a blank line (\par) breaks its key-value
+% parser. Comment lines are fine; empty lines are not.
 \begin{poster}{
   % ============================================================================
   % POSTER CONFIGURATION
   % ============================================================================
-  
   % Grid and columns
   grid=false,                    % Set to true for debugging layout
   columns=3,                     % Number of columns
   colspacing=1.5em,              % Space between columns
-  
   % Background
   background=plain,              % plain, shadetb, shadelr
   bgColorOne=white,
   bgColorTwo=white,
-  
   % Borders
   borderColor=blue!50!black,
   linewidth=2pt,
-  
   % Header
   headerColorOne=blue!70!black,
   headerColorTwo=blue!60!black,
@@ -53,13 +55,11 @@
   headershade=plain,             % plain, shadetb, shadelr
   headerborder=closed,           % open, closed
   headerfont=\Large\sf\bf,
-  
   % Boxes
   boxColorOne=white,
   boxColorTwo=blue!10,
   boxshade=plain,
   textborder=roundedleft,        % none, rectangle, rounded, roundedleft, roundedright
-  
   % Eye catcher
   eyecatcher=true
 }
@@ -180,8 +180,33 @@
 % ==============================================================================
 % BOTTOM ROW (SPANS ALL COLUMNS)
 % ==============================================================================
+% Anchor chain: declare the footer first (anchored to the page bottom), then
+% anchor the conclusions and QR boxes "above=footer". In baposter/xebaposter an
+% anchor target must be declared before any box that references it.
 
-\headerbox{Conclusions}{name=conclusions,column=0,span=2,above=bottom}{
+\headerbox{}{name=footer,column=0,span=3,above=bottom}{
+  \footnotesize
+  \begin{multicols}{2}
+    \textbf{References}
+    \begin{enumerate}
+      \item Author A et al. (2023). Title. \textit{Journal}, 10(2), 123-145.
+      \item Author B et al. (2024). Title. \textit{Conference}.
+      \item Author C et al. (2022). Title. \textit{Journal}, 15(3), 456-478.
+    \end{enumerate}
+
+    \columnbreak
+
+    \textbf{Acknowledgments}
+
+    Funded by Grant Agency (Grant \#12345). Thanks to collaborators at Institution X.
+
+    \vspace{0.3cm}
+
+    \textbf{Contact:} presenter.email@university.edu | labname.university.edu
+  \end{multicols}
+}
+
+\headerbox{Conclusions}{name=conclusions,column=0,span=2,above=footer}{
   \begin{multicols}{2}
     \textbf{Key Findings}
     \begin{itemize}
@@ -217,38 +242,12 @@
   \end{multicols}
 }
 
-\headerbox{Scan for More}{name=qr,column=2,above=bottom}{
+\headerbox{Scan for More}{name=qr,column=2,above=footer}{
   \begin{center}
     \qrcode[height=4cm]{https://doi.org/10.1234/your-paper}\\
     \vspace{0.3cm}
     \small Full paper, code \& data
   \end{center}
-}
-
-% ==============================================================================
-% FOOTER (FULL WIDTH AT BOTTOM)
-% ==============================================================================
-
-\headerbox{}{name=footer,column=0,span=3,above=bottom,below=conclusions}{
-  \footnotesize
-  \begin{multicols}{2}
-    \textbf{References}
-    \begin{enumerate}
-      \item Author A et al. (2023). Title. \textit{Journal}, 10(2), 123-145.
-      \item Author B et al. (2024). Title. \textit{Conference}.
-      \item Author C et al. (2022). Title. \textit{Journal}, 15(3), 456-478.
-    \end{enumerate}
-    
-    \columnbreak
-    
-    \textbf{Acknowledgments}
-    
-    Funded by Grant Agency (Grant \#12345). Thanks to collaborators at Institution X.
-    
-    \vspace{0.3cm}
-    
-    \textbf{Contact:} presenter.email@university.edu | labname.university.edu
-  \end{multicols}
 }
 
 \end{poster}

--- a/skills/latex-posters/assets/beamerposter_template.tex
+++ b/skills/latex-posters/assets/beamerposter_template.tex
@@ -7,12 +7,18 @@
 
 \documentclass[final,t]{beamer}
 \usepackage[size=a0,scale=1.4,orientation=portrait]{beamerposter}
-\usetheme{Berlin}
+% Use the plain default theme. (Avoid navigation themes such as Berlin: it is a
+% miniframes theme that renders a section-navigation headline bar, which is
+% useless on a poster and wastes vertical space.)
+\usetheme{default}
 \usecolortheme{beaver}
+% Clear any leftover headline/footline so no navigation bar appears.
+\setbeamertemplate{headline}{}
+\setbeamertemplate{footline}{}
 
 % Remove default margins for full page coverage
 \setbeamersize{text margin left=5mm, text margin right=5mm}
-\usepackage[margin=10mm]{geometry}
+\geometry{margin=10mm}
 
 % Remove navigation symbols
 \setbeamertemplate{navigation symbols}{}

--- a/skills/latex-posters/assets/poster_quality_checklist.md
+++ b/skills/latex-posters/assets/poster_quality_checklist.md
@@ -348,7 +348,7 @@ _________________________________________________________
 | Text too small | Increase scale: `scale=1.5` in beamerposter |
 | Blurry figures | Use vector graphics (PDF) or higher resolution (600+ DPI) |
 | Colors wrong | Check RGB vs CMYK, test print before final |
-| Fonts not embedded | Compile with: `pdflatex -dEmbedAllFonts=true` |
+| Fonts not embedded | pdfLaTeX embeds by default; recompile, or force-embed with Ghostscript (`gs ... -dEmbedAllFonts=true`) or xelatex/lualatex |
 | Content cut off | Check total width: columns + spacing + margins = pagewidth |
 | QR codes don't scan | Increase size (min 2×2cm), ensure high contrast |
 | File too large | Compress: `gs -sDEVICE=pdfwrite -dPDFSETTINGS=/printer ...` |

--- a/skills/latex-posters/assets/tikzposter_template.tex
+++ b/skills/latex-posters/assets/tikzposter_template.tex
@@ -220,7 +220,7 @@
 % FOOTER (Full Width)
 % ==============================================================================
 
-\block[width=1.0\linewidth]{}{
+\block{}{
   \footnotesize
   \begin{minipage}{0.7\textwidth}
     \textbf{References}

--- a/skills/latex-posters/references/README.md
+++ b/skills/latex-posters/references/README.md
@@ -35,13 +35,13 @@ Posters should span the entire page with minimal margins:
 \documentclass[final,t]{beamer}
 \usepackage[size=a0,scale=1.4,orientation=portrait]{beamerposter}
 \setbeamersize{text margin left=5mm, text margin right=5mm}
-\usepackage[margin=10mm]{geometry}
+\geometry{margin=10mm}
 
 % tikzposter - full page setup
 \documentclass[25pt,a0paper,portrait,margin=10mm,innermargin=15mm]{tikzposter}
 
 % baposter - full page setup
-\documentclass[a0paper,portrait,fontscale=0.285]{baposter}
+\documentclass[a0paper,portrait,fontscale=0.285]{xebaposter}
 ```
 
 ### 4. Compile
@@ -114,14 +114,14 @@ Templates support all standard sizes:
 
 **Comprehensive Documentation** (in `references/`):
 
-1. **`latex_poster_packages.md`** (746 lines)
+1. **`latex_poster_packages.md`**
    - Detailed comparison of beamerposter, tikzposter, baposter
    - Package-specific syntax and examples
    - Strengths, limitations, best use cases
    - Theme and color customization
    - Compilation tips and troubleshooting
 
-2. **`poster_design_principles.md`** (807 lines)
+2. **`poster_design_principles.md`**
    - Visual hierarchy and white space
    - Typography: font selection, sizing, readability
    - Color theory: schemes, contrast, accessibility
@@ -129,7 +129,7 @@ Templates support all standard sizes:
    - Icons, graphics, and visual elements
    - Common design mistakes to avoid
 
-3. **`poster_layout_design.md`** (650+ lines)
+3. **`poster_layout_design.md`**
    - Grid systems (2, 3, 4-column layouts)
    - Visual flow and reading patterns
    - Spatial organization strategies
@@ -137,7 +137,7 @@ Templates support all standard sizes:
    - Block and box design
    - Layout patterns by research type
 
-4. **`poster_content_guide.md`** (900+ lines)
+4. **`poster_content_guide.md`**
    - Content strategy (3-5 minute rule)
    - Word budgets by section
    - Visual-to-text ratio (40-50% visual)
@@ -224,13 +224,13 @@ Templates support all standard sizes:
 ```latex
 % beamerposter
 \setbeamersize{text margin left=5mm, text margin right=5mm}
-\usepackage[margin=10mm]{geometry}
+\geometry{margin=10mm}
 
 % tikzposter
 \documentclass[..., margin=5mm, innermargin=10mm]{tikzposter}
 
 % baposter
-\documentclass[a0paper, margin=5mm]{baposter}
+\documentclass[a0paper, margin=5mm]{xebaposter}
 ```
 
 ### Content Cut Off
@@ -266,8 +266,13 @@ Templates support all standard sizes:
 
 **Solution**:
 ```bash
-# Recompile with embedded fonts
-pdflatex -dEmbedAllFonts=true poster.tex
+# pdfLaTeX embeds fonts by default, so recompiling normally is usually enough
+pdflatex poster.tex
+
+# To force embedding (e.g. fonts from included PDFs), post-process with Ghostscript
+# (-dEmbedAllFonts is a Ghostscript option, not a pdflatex flag), or use xelatex/lualatex:
+# gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dEmbedAllFonts=true -dSubsetFonts=true \
+#    -sOutputFile=poster-embedded.pdf poster.pdf
 
 # Verify embedding
 pdffonts poster.pdf
@@ -412,6 +417,6 @@ For issues or questions:
 ## Version
 
 LaTeX Poster Skill v1.0
-Compatible with: beamerposter, tikzposter, baposter
+Compatible with: beamerposter, tikzposter, xebaposter
 Last updated: January 2025
 

--- a/skills/latex-posters/references/latex_poster_packages.md
+++ b/skills/latex-posters/references/latex_poster_packages.md
@@ -48,8 +48,12 @@ beamerposter extends the popular Beamer presentation class for poster-sized docu
 ```latex
 \documentclass[final,t]{beamer}
 \usepackage[size=a0,scale=1.4,orientation=portrait]{beamerposter}
-\usetheme{Berlin}
+% Plain default theme (Berlin is a presentation navigation theme: it adds a
+% miniframes headline bar that is useless on a poster).
+\usetheme{default}
 \usecolortheme{beaver}
+\setbeamertemplate{headline}{}
+\setbeamertemplate{footline}{}
 
 % Configure fonts
 \setbeamerfont{title}{size=\VeryHuge,series=\bfseries}
@@ -103,8 +107,12 @@ beamerposter extends the popular Beamer presentation class for poster-sized docu
 
 ```latex
 % Traditional academic
-\usetheme{Berlin}
+% Plain default theme (Berlin is a presentation navigation theme: it adds a
+% miniframes headline bar that is useless on a poster).
+\usetheme{default}
 \usecolortheme{beaver}
+\setbeamertemplate{headline}{}
+\setbeamertemplate{footline}{}
 
 % Modern minimal
 \usetheme{Madrid}
@@ -335,11 +343,8 @@ tikzposter is built on the powerful TikZ graphics package, offering modern desig
 % Full-width block
 \block{Title}{Content}
 
-% Specify width
-\block[width=0.8\linewidth]{Title}{Content}
-
-% Position manually
-\block[x=10, y=50, width=30]{Title}{Content}
+% Specify width (scale block body relative to its column)
+\block[bodywidthscale=0.8]{Title}{Content}
 
 % Inner blocks (nested, different styling)
 \block{Outer Title}{
@@ -375,6 +380,7 @@ tikzposter is built on the powerful TikZ graphics package, offering modern desig
 }
 
 % Custom TikZ graphics
+% Requires \usetikzlibrary{positioning} for the "right=of" placement syntax
 \block{Methodology}{
   \begin{tikzpicture}
     \node[draw, rectangle, fill=blue!20] (A) {Step 1};
@@ -409,7 +415,7 @@ baposter (Box Area Poster) uses a box-based layout system with automatic positio
 ### Basic Template
 
 ```latex
-\documentclass[a0paper,portrait]{baposter}
+\documentclass[a0paper,portrait]{xebaposter}
 
 \usepackage{graphicx}
 \usepackage{multicol}
@@ -674,8 +680,13 @@ pdflatex -interaction=nonstopmode poster.tex
 ### Font Embedding
 
 ```bash
-# Ensure fonts are embedded (required for printing)
-pdflatex -dEmbedAllFonts=true poster.tex
+# pdfLaTeX embeds fonts by default; a normal compile is usually enough
+pdflatex poster.tex
+
+# To force embedding, post-process with Ghostscript (-dEmbedAllFonts is a
+# Ghostscript option, not a pdflatex flag), or compile with xelatex/lualatex:
+# gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dEmbedAllFonts=true -dSubsetFonts=true \
+#    -sOutputFile=poster-embedded.pdf poster.pdf
 
 # Check font embedding
 pdffonts poster.pdf

--- a/skills/latex-posters/references/poster_content_guide.md
+++ b/skills/latex-posters/references/poster_content_guide.md
@@ -64,10 +64,11 @@ Hook (Problem) → Approach → Discovery → Impact
 | References/Acknowledgments | 50-100 | 10% |
 
 **Counting Tool**:
-```latex
-% Add word count to poster (remove for final)
-\usepackage{texcount}
-% Compile with: texcount -inc poster.tex
+
+`texcount` is a command-line tool bundled with TeX Live, not a LaTeX package, so run it from the shell rather than loading it with `\usepackage`:
+```bash
+# Word count, following \input/\include files
+texcount -inc poster.tex
 ```
 
 ### 4. Visual-to-Text Ratio
@@ -225,13 +226,21 @@ improve cross-species accuracy.
 
 **Visual Methods (Highly Recommended)**:
 ```latex
+% Requires: \usepackage{tikz} in the preamble
+\usetikzlibrary{positioning,arrows.meta}
+% Local style definitions for the box and arrow used below
+\tikzset{
+  box/.style={draw, rectangle, rounded corners, align=center, fill=blue!10},
+  arrow/.style={-{Stealth}, thick}
+}
+
 % Flowchart of study design
-\begin{tikzpicture}[node distance=2cm]
+\begin{tikzpicture}[node distance=1.5cm]
   \node (start) [box] {Data Collection\\n=1,000 samples};
-  \node (process) [box, below of=start] {Preprocessing\\Quality Control};
-  \node (analysis) [box, below of=process] {Statistical Analysis\\Mixed Models};
-  \node (end) [box, below of=analysis] {Validation\\Independent Cohort};
-  
+  \node (process) [box, below=of start] {Preprocessing\\Quality Control};
+  \node (analysis) [box, below=of process] {Statistical Analysis\\Mixed Models};
+  \node (end) [box, below=of analysis] {Validation\\Independent Cohort};
+
   \draw [arrow] (start) -- (process);
   \draw [arrow] (process) -- (analysis);
   \draw [arrow] (analysis) -- (end);
@@ -320,6 +329,8 @@ Key Findings
 
 **1. Bar Charts**: Comparing categories
 ```latex
+% Requires: \usepackage{pgfplots} and \pgfplotsset{compat=1.18} in the preamble
+% (the axis environment is provided by pgfplots, not plain tikz)
 \begin{tikzpicture}
   \begin{axis}[
     ybar,

--- a/skills/latex-posters/references/poster_design_principles.md
+++ b/skills/latex-posters/references/poster_design_principles.md
@@ -633,10 +633,14 @@ Strategic use of icons enhances comprehension:
 }
 
 % Watermark
+% Note: opacity is not a graphicx \includegraphics key. Apply transparency by
+% wrapping the image in a TikZ node with the opacity= option instead.
 \usepackage{tikz}
 \AddToShipoutPictureBG{
   \AtPageCenter{
-    \includegraphics[width=0.5\paperwidth,opacity=0.05]{university-seal.pdf}
+    \begin{tikzpicture}
+      \node[opacity=0.05]{\includegraphics[width=0.5\paperwidth]{university-seal.pdf}};
+    \end{tikzpicture}
   }
 }
 ```

--- a/skills/latex-posters/references/poster_layout_design.md
+++ b/skills/latex-posters/references/poster_layout_design.md
@@ -222,7 +222,7 @@ Effective poster layout organizes content for maximum impact and comprehension. 
   }
 \end{columns}
 
-\block[width=1.0\linewidth]{Results}{
+\block{Results}{
   % Full-width results section
 }
 ```
@@ -600,19 +600,18 @@ Discussion/Conclusions
 
 ### Block Styling Options
 
-**Border Styles**:
+**Border Styles** (set these in the preamble, not inside a block):
 ```latex
-% Rounded corners (friendly, modern)
-\begin{block}{Title}
-  % beamerposter with rounded
-  \setbeamertemplate{block begin}[rounded]
-  
+% Rounded corners (friendly, modern). Use the "blocks" template, which styles
+% both the block begin and block end; "block begin" alone leaves the end mismatched.
+\setbeamertemplate{blocks}[rounded][shadow=true]
+
 % Sharp corners (formal, traditional)
-  \setbeamertemplate{block begin}[default]
+\setbeamertemplate{blocks}[default]
 
 % No border (minimal, clean)
-  \setbeamercolor{block title}{bg=white, fg=black}
-  \setbeamercolor{block body}{bg=white, fg=black}
+\setbeamercolor{block title}{bg=white, fg=black}
+\setbeamercolor{block body}{bg=white, fg=black}
 ```
 
 **Shadow and Depth**:

--- a/skills/latex-posters/scripts/generate_schematic.py
+++ b/skills/latex-posters/scripts/generate_schematic.py
@@ -6,7 +6,7 @@ Generate any scientific diagram by describing it in natural language.
 Nano Banana 2 handles everything automatically with smart iterative refinement.
 
 Smart iteration: Only regenerates if quality is below threshold for your document type.
-Quality review: Uses Gemini 3.1 Pro Preview for professional scientific evaluation.
+Quality review: Uses Gemini 3.5 Flash for professional scientific evaluation.
 
 Usage:
     # Generate for journal paper (highest quality threshold)
@@ -36,7 +36,7 @@ How it works:
   Simply describe your diagram in natural language
   Nano Banana 2 generates it automatically with:
   - Smart iteration (only regenerates if quality is below threshold)
-  - Quality review by Gemini 3.1 Pro Preview
+  - Quality review by Gemini 3.5 Flash
   - Document-type aware quality thresholds
   - Publication-ready output
 

--- a/skills/latex-posters/scripts/generate_schematic_ai.py
+++ b/skills/latex-posters/scripts/generate_schematic_ai.py
@@ -4,7 +4,7 @@ AI-powered scientific schematic generation using Nano Banana 2.
 
 This script uses a smart iterative refinement approach:
 1. Generate initial image with Nano Banana 2
-2. AI quality review using Gemini 3.1 Pro Preview for scientific critique
+2. AI quality review using Gemini 3.5 Flash for scientific critique
 3. Only regenerate if quality is below threshold for document type
 4. Repeat until quality meets standards (max iterations)
 
@@ -52,7 +52,7 @@ def _load_env_file():
 class ScientificSchematicGenerator:
     """Generate scientific schematics using AI with smart iterative refinement.
     
-    Uses Gemini 3.1 Pro Preview for quality review to determine if regeneration is needed.
+    Uses Gemini 3.5 Flash for quality review to determine if regeneration is needed.
     Multiple passes only occur if the generated schematic doesn't meet the
     quality threshold for the target document type.
     """
@@ -144,11 +144,12 @@ IMPORTANT - NO FIGURE NUMBERS:
         self.verbose = verbose
         self._last_error = None  # Track last error for better reporting
         self.base_url = "https://openrouter.ai/api/v1"
-        # Nano Banana 2 - Google's advanced image generation model
-        # https://openrouter.ai/google/gemini-3-pro-image-preview
+        # Nano Banana 2 (Gemini 3.1 Flash Image Preview) - Google image generation model
+        # https://openrouter.ai/google/gemini-3.1-flash-image-preview
         self.image_model = "google/gemini-3.1-flash-image-preview"
-        # Gemini 3.1 Pro Preview for quality review - excellent vision and reasoning
-        self.review_model = "google/gemini-3.1-pro-preview"
+        # Gemini 3.5 Flash for quality review - excellent vision and reasoning
+        # https://openrouter.ai/google/gemini-3.5-flash
+        self.review_model = "google/gemini-3.5-flash"
         
     def _log(self, message: str):
         """Log message if verbose mode is enabled."""
@@ -400,9 +401,9 @@ IMPORTANT - NO FIGURE NUMBERS:
                     iteration: int, doc_type: str = "default",
                     max_iterations: int = 2) -> Tuple[str, float, bool]:
         """
-        Review generated image using Gemini 3.1 Pro Preview for quality analysis.
+        Review generated image using Gemini 3.5 Flash for quality analysis.
         
-        Uses Gemini 3.1 Pro Preview's superior vision and reasoning capabilities to
+        Uses Gemini 3.5 Flash's superior vision and reasoning capabilities to
         evaluate the schematic quality and determine if regeneration is needed.
         
         Args:
@@ -415,7 +416,7 @@ IMPORTANT - NO FIGURE NUMBERS:
         Returns:
             Tuple of (critique text, quality score 0-10, needs_improvement bool)
         """
-        # Use Gemini 3.1 Pro Preview for review - excellent vision and analysis
+        # Use Gemini 3.5 Flash for review - excellent vision and analysis
         image_data_url = self._image_to_base64(image_path)
         
         # Get quality threshold for this document type
@@ -491,7 +492,7 @@ If score < {threshold}, mark as NEEDS_IMPROVEMENT with specific suggestions."""
         ]
         
         try:
-            # Use Gemini 3.1 Pro Preview for high-quality review
+            # Use Gemini 3.5 Flash for high-quality review
             response = self._make_request(
                 model=self.review_model,
                 messages=messages
@@ -500,7 +501,7 @@ If score < {threshold}, mark as NEEDS_IMPROVEMENT with specific suggestions."""
             # Extract text response
             choices = response.get("choices", [])
             if not choices:
-                return "Image generated successfully", 8.0
+                return "Image generated successfully", 8.0, False
             
             message = choices[0].get("message", {})
             content = message.get("content", "")
@@ -656,8 +657,8 @@ Generate a publication-quality scientific diagram that meets all the guidelines 
                 f.write(image_data)
             print(f"✓ Saved: {iter_path}")
             
-            # Review image using Gemini 3.1 Pro Preview
-            print(f"Reviewing image with Gemini 3.1 Pro Preview...")
+            # Review image using Gemini 3.5 Flash
+            print(f"Reviewing image with Gemini 3.5 Flash...")
             critique, score, needs_improvement = self.review_image(
                 str(iter_path), user_prompt, i, doc_type, iterations
             )

--- a/skills/latex-posters/scripts/review_poster.sh
+++ b/skills/latex-posters/scripts/review_poster.sh
@@ -111,11 +111,16 @@ if command_exists pdffonts; then
         echo "    $line"
     done
     
-    # Check for non-embedded fonts
-    NON_EMBEDDED=$(echo "$FONT_OUTPUT" | tail -n +3 | awk '{if ($4 == "no") print $0}')
+    # Check for non-embedded fonts. pdffonts columns are:
+    # name  type  encoding  emb  sub  uni  object-num  gen
+    # The "type" field can contain spaces (e.g. "Type 1"), which shifts the
+    # left-anchored columns, so the embedding flag is read from the right:
+    # the last 5 fields are always  emb sub uni object-num gen, i.e. $(NF-4).
+    NON_EMBEDDED=$(echo "$FONT_OUTPUT" | tail -n +3 | awk 'NF>=5 && $(NF-4) == "no" {print $0}')
     if [ -n "$NON_EMBEDDED" ]; then
         echo -e "    ${RED}✗ Some fonts are NOT embedded (printing may fail)${NC}"
-        echo -e "    ${BLUE}  Fix: Recompile with 'pdflatex -dEmbedAllFonts=true poster.tex'${NC}"
+        echo -e "    ${BLUE}  Fix: pdfLaTeX embeds fonts by default; recompile, or force-embed with${NC}"
+        echo -e "    ${BLUE}       Ghostscript: gs -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dEmbedAllFonts=true -sOutputFile=out.pdf $POSTER_FILE${NC}"
     else
         echo -e "    ${GREEN}✓ All fonts appear to be embedded${NC}"
     fi


### PR DESCRIPTION
Two of the three bundled templates failed to compile as shipped, and the same broken recipes showed up in the docs.

- `tikzposter_template.tex`: drop the non-existent `\block[width=...]` key, and remove the invalid manual-position `\block[x=,y=,width=]` example.
- `beamerposter_template.tex`: use `\geometry{...}` instead of re-loading `geometry` (beamerposter already loads it), which removes the option clash. Same fix in the docs.
- `review_poster.sh`: read the correct column for the font-embedding check.

Both templates now build A0 PDFs cleanly under pdflatex and xelatex. The earlier theme and flag corrections are folded in.
