### PR TITLE
polars: fix removed/renamed and deprecated APIs across the skill (1.41)

### DIFF
--- a/skills/polars/SKILL.md
+++ b/skills/polars/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polars
-description: Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas replacement. For larger-than-RAM data use dask or vaex.
+description: 'Fast DataFrame library built on Apache Arrow with lazy evaluation, a query optimizer, and multithreaded parallel execution. Use as a faster pandas replacement for ETL and analytics on datasets from megabytes to roughly 100GB, and use its streaming, out-of-core engine to process larger-than-memory data that does not fit in RAM, with predicate and projection pushdown when scanning Parquet or CSV, plus joins, group-bys, window and rolling operations. For distributed multi-machine clusters consider dask or Spark.'
 license: https://github.com/pola-rs/polars/blob/main/LICENSE
 metadata:
     skill-author: K-Dense Inc.
@@ -18,7 +18,7 @@ Polars is a lightning-fast DataFrame library for Python and Rust built on Apache
 
 Install Polars:
 ```python
-uv pip install polars
+uv add polars
 ```
 
 Basic DataFrame creation and operations:
@@ -140,8 +140,8 @@ df.with_columns(
 
 # Parallel computation (all columns computed in parallel)
 df.with_columns(
-    pl.col("value") * 10,
-    pl.col("value") * 100,
+    value_x10=pl.col("value") * 10,
+    value_x100=pl.col("value") * 100,
 )
 ```
 
@@ -175,7 +175,7 @@ Common aggregations within `group_by` context:
 - `pl.col("x").sum()` - sum values
 - `pl.col("x").mean()` - average
 - `pl.col("x").min()` / `pl.col("x").max()` - extremes
-- `pl.first()` / `pl.last()` - first/last values
+- `pl.col("x").first()` / `pl.col("x").last()` - first/last values (give each an explicit `.alias()` when both are used in one agg, or they collide)
 
 ### Window Functions with `over()`
 Apply aggregations while preserving row count:
@@ -266,7 +266,7 @@ pl.concat([df1, df2], how="diagonal")
 Reshape data:
 ```python
 # Pivot (wide format)
-df.pivot(values="sales", index="date", columns="product")
+df.pivot("product", index="date", values="sales")
 
 # Unpivot (long format)
 df.unpivot(index="id", on=["col1", "col2"])
@@ -331,7 +331,7 @@ For comprehensive migration guide, load `references/pandas_migration.md`.
 
 3. **Use streaming for very large data:**
    ```python
-   lf.collect(streaming=True)
+   lf.collect(engine="streaming")
    ```
 
 4. **Select only needed columns early:**

--- a/skills/polars/references/best_practices.md
+++ b/skills/polars/references/best_practices.md
@@ -81,7 +81,7 @@ Enable streaming for datasets larger than RAM:
 ```python
 # Streaming mode processes data in chunks
 lf = pl.scan_parquet("very_large.parquet")
-result = lf.filter(pl.col("value") > 100).collect(streaming=True)
+result = lf.filter(pl.col("value") > 100).collect(engine="streaming")
 
 # Or use sink for direct streaming writes
 lf.filter(pl.col("value") > 100).sink_parquet("output.parquet")
@@ -98,7 +98,7 @@ df = pl.read_csv("data.csv")
 # Good: Specify optimal types
 df = pl.read_csv(
     "data.csv",
-    dtypes={
+    schema_overrides={
         "id": pl.UInt32,  # Instead of Int64 if values fit
         "category": pl.Categorical,  # For low-cardinality strings
         "date": pl.Date,  # Instead of String
@@ -234,25 +234,27 @@ df.select("col1", "col2", "col3")
 df.select(pl.col("^sales_.*$"))
 
 # Starts with
-df.select(pl.col("^sales"))
+df.select(pl.col("^sales.*$"))
 
 # Ends with
-df.select(pl.col("_total$"))
+df.select(pl.col("^.*_total$"))
 
 # Contains
-df.select(pl.col(".*revenue.*"))
+df.select(pl.col("^.*revenue.*$"))
 ```
 
 **By type:**
 ```python
+import polars.selectors as cs
+
 # All numeric columns
-df.select(pl.col(pl.NUMERIC_DTYPES))
+df.select(cs.numeric())
 
 # All string columns
 df.select(pl.col(pl.Utf8))
 
 # Multiple types
-df.select(pl.col(pl.NUMERIC_DTYPES, pl.Boolean))
+df.select(cs.numeric() | cs.boolean())
 ```
 
 **Exclude columns:**
@@ -336,7 +338,7 @@ df = df.with_columns(result=pl.col("value") * 2)
 
 ```python
 # Bad: Polars is immutable, this doesn't work as expected
-df["new_col"] = df["old_col"] * 2  # May work but not recommended
+df["new_col"] = df["old_col"] * 2  # Raises TypeError: Series assignment by index is unsupported
 
 # Good: Functional style
 df = df.with_columns(new_col=pl.col("old_col") * 2)
@@ -377,7 +379,7 @@ df = pl.read_csv("data.csv")
 # Good: Specify types for correctness and performance
 df = pl.read_csv(
     "data.csv",
-    dtypes={"id": pl.Int64, "date": pl.Date, "category": pl.Categorical}
+    schema_overrides={"id": pl.Int64, "date": pl.Date, "category": pl.Categorical}
 )
 ```
 
@@ -429,7 +431,7 @@ print(lf.explain())  # See query plan
 lf = pl.scan_parquet("data.parquet")
 
 # 2. Stream results
-result = lf.collect(streaming=True)
+result = lf.collect(engine="streaming")
 
 # 3. Select only needed columns
 lf = lf.select("col1", "col2")
@@ -538,7 +540,7 @@ lf = pl.scan_parquet("data/*.parquet")  # Parallel reading
 # 3. Specify schema when known
 lf = pl.scan_csv(
     "data.csv",
-    dtypes={"id": pl.Int64, "date": pl.Date}
+    schema_overrides={"id": pl.Int64, "date": pl.Date}
 )
 
 # 4. Use predicate pushdown

--- a/skills/polars/references/core_concepts.md
+++ b/skills/polars/references/core_concepts.md
@@ -78,11 +78,13 @@ df.select(pl.all() * 2)
 
 **Pattern matching:**
 ```python
+import polars.selectors as cs
+
 # All columns ending with "_value"
 df.select(pl.col("^.*_value$") * 100)
 
 # All numeric columns
-df.select(pl.col(pl.NUMERIC_DTYPES) + 1)
+df.select(cs.numeric() + 1)
 ```
 
 **Exclude patterns:**
@@ -271,7 +273,7 @@ Process data larger than memory:
 ```python
 # Enable streaming for very large datasets
 lf = pl.scan_csv("very_large.csv")
-result = lf.filter(pl.col("age") > 25).collect(streaming=True)
+result = lf.filter(pl.col("age") > 25).collect(engine="streaming")
 ```
 
 **Streaming benefits:**

--- a/skills/polars/references/io_guide.md
+++ b/skills/polars/references/io_guide.md
@@ -21,7 +21,7 @@ df = pl.read_csv(
     columns=["col1", "col2"],  # Select specific columns
     n_rows=1000,  # Read only first 1000 rows
     skip_rows=10,  # Skip first 10 rows
-    dtypes={"col1": pl.Int64, "col2": pl.Utf8},  # Specify types
+    schema_overrides={"col1": pl.Int64, "col2": pl.Utf8},  # Specify types
     null_values=["NA", "null", ""],  # Define null values
     encoding="utf-8",
     ignore_errors=False
@@ -146,8 +146,8 @@ lf = pl.scan_ndjson("data.ndjson")
 ```python
 df = pl.read_json("data.json")
 
-# From JSON string
-df = pl.read_json('{"col1": [1, 2], "col2": ["a", "b"]}')
+# From JSON string (a str is treated as a path; pass bytes for a literal document)
+df = pl.read_json('{"col1": [1, 2], "col2": ["a", "b"]}'.encode())
 ```
 
 ### Writing JSON
@@ -159,8 +159,9 @@ df.write_ndjson("output.ndjson")
 # Write standard JSON
 df.write_json("output.json")
 
-# Pretty printed
-df.write_json("output.json", pretty=True, row_oriented=False)
+# write_json takes only `file` in polars 1.x; for pretty/row-oriented output, serialize rows yourself
+import json
+json.dump(df.to_dicts(), open("output.json", "w"), indent=2)
 ```
 
 ## Excel Files
@@ -173,17 +174,16 @@ df = pl.read_excel("data.xlsx")
 
 # Specific sheet
 df = pl.read_excel("data.xlsx", sheet_name="Sheet1")
-# Or by index
-df = pl.read_excel("data.xlsx", sheet_id=0)
+# Or by index (sheet_id is 1-indexed; sheet_id=0 returns a dict of all sheets)
+df = pl.read_excel("data.xlsx", sheet_id=1)
 
 # With options
 df = pl.read_excel(
     "data.xlsx",
     sheet_name="Sheet1",
-    columns=["A", "B", "C"],  # Excel columns
-    n_rows=100,
-    skip_rows=5,
-    has_header=True
+    columns=["name", "age", "city"],  # by column name (or integer index), not Excel letters
+    has_header=True,
+    read_options={"n_rows": 100, "skip_rows": 5}  # engine-specific (calamine)
 )
 ```
 
@@ -193,10 +193,11 @@ df = pl.read_excel(
 # Write to Excel
 df.write_excel("output.xlsx")
 
-# Multiple sheets
-with pl.ExcelWriter("output.xlsx") as writer:
-    df1.write_excel(writer, worksheet="Sheet1")
-    df2.write_excel(writer, worksheet="Sheet2")
+# Multiple sheets: pass a shared xlsxwriter Workbook (pl.ExcelWriter does not exist)
+import xlsxwriter
+with xlsxwriter.Workbook("output.xlsx") as wb:
+    df1.write_excel(workbook=wb, worksheet="Sheet1")
+    df2.write_excel(workbook=wb, worksheet="Sheet2")
 ```
 
 ## Database Connectivity
@@ -207,7 +208,7 @@ with pl.ExcelWriter("output.xlsx") as writer:
 import polars as pl
 
 # Read entire table
-df = pl.read_database("SELECT * FROM users", connection_uri="postgresql://...")
+df = pl.read_database("SELECT * FROM users", connection=conn)  # conn: a DBAPI2/SQLAlchemy connection
 
 # Using connectorx for better performance
 df = pl.read_database_uri(
@@ -229,7 +230,7 @@ df.write_database("table_name", connection=engine)
 df.write_database(
     "table_name",
     connection=engine,
-    if_exists="replace",  # or "append", "fail"
+    if_table_exists="replace",  # or "append", "fail"
 )
 ```
 
@@ -305,9 +306,9 @@ os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/path/to/credentials.json"
 
 ```python
 # Read from BigQuery
-df = pl.read_database(
+df = pl.read_database_uri(
     "SELECT * FROM project.dataset.table",
-    connection_uri="bigquery://project"
+    uri="bigquery://project"
 )
 
 # Or using Google Cloud SDK
@@ -419,7 +420,7 @@ rows = df.to_dicts()
 
 # From list of tuples
 data = [("Alice", 25), ("Bob", 30)]
-df = pl.DataFrame(data, schema=["name", "age"])
+df = pl.DataFrame(data, schema=["name", "age"], orient="row")
 ```
 
 ## Streaming Large Files
@@ -429,11 +430,11 @@ For datasets larger than memory, use lazy mode with streaming:
 ```python
 # Streaming mode
 lf = pl.scan_csv("very_large.csv")
-result = lf.filter(pl.col("value") > 100).collect(streaming=True)
+result = lf.filter(pl.col("value") > 100).collect(engine="streaming")
 
 # Streaming with multiple files
 lf = pl.scan_parquet("data/*.parquet")
-result = lf.group_by("category").agg(pl.col("value").sum()).collect(streaming=True)
+result = lf.group_by("category").agg(pl.col("value").sum()).collect(engine="streaming")
 ```
 
 ## Best Practices
@@ -478,7 +479,7 @@ result = (
 )
 
 # 3. Use streaming for very large data
-result = lf.filter(...).select(...).collect(streaming=True)
+result = lf.filter(...).select(...).collect(engine="streaming")
 
 # 4. Read only needed rows during development
 df = pl.read_csv("large.csv", n_rows=10000)  # Sample for testing
@@ -504,15 +505,15 @@ lf.sink_parquet("output.parquet")  # Streaming write
 # 1. Specify dtypes when reading CSV
 df = pl.read_csv(
     "data.csv",
-    dtypes={"id": pl.Int64, "name": pl.Utf8}  # Avoids inference
+    schema_overrides={"id": pl.Int64, "name": pl.Utf8}  # Avoids inference
 )
 
 # 2. Use appropriate compression
 df.write_parquet("output.parquet", compression="snappy")  # Fast
 df.write_parquet("output.parquet", compression="zstd")    # Better compression
 
-# 3. Parallel reading
-df = pl.read_csv("data.csv", parallel="auto")
+# 3. CSV reads parallelize automatically (read_csv has no `parallel` argument)
+df = pl.read_csv("data.csv")
 
 # 4. Read multiple files in parallel
 lf = pl.scan_parquet("data/*.parquet")  # Automatic parallel read
@@ -544,7 +545,7 @@ else:
 schema = pl.read_csv("data.csv", n_rows=1000).schema
 
 # Use inferred schema for full read
-df = pl.read_csv("data.csv", dtypes=schema)
+df = pl.read_csv("data.csv", schema_overrides=schema)
 
 # Define schema explicitly
 schema = {
@@ -553,5 +554,5 @@ schema = {
     "date": pl.Date,
     "value": pl.Float64
 }
-df = pl.read_csv("data.csv", dtypes=schema)
+df = pl.read_csv("data.csv", schema_overrides=schema)
 ```

--- a/skills/polars/references/operations.md
+++ b/skills/polars/references/operations.md
@@ -17,11 +17,13 @@ df.select(pl.col("name"), pl.col("age"))
 
 **Pattern-based selection:**
 ```python
+import polars.selectors as cs
+
 # All columns starting with "sales_"
 df.select(pl.col("^sales_.*$"))
 
 # All numeric columns
-df.select(pl.col(pl.NUMERIC_DTYPES))
+df.select(cs.numeric())
 
 # All columns except specific ones
 df.select(pl.all().exclude("id", "timestamp"))
@@ -294,9 +296,9 @@ df.with_columns(
 **Time-based rolling:**
 ```python
 df.with_columns(
-    rolling_avg=pl.col("value").rolling_mean(
-        window_size="7d",
-        by="date"
+    rolling_avg=pl.col("value").rolling_mean_by(
+        "date",
+        window_size="7d"
     )
 )
 ```
@@ -481,7 +483,7 @@ df.with_columns(
 # Add duration
 df.with_columns(
     next_week=pl.col("date") + pl.duration(weeks=1),
-    next_month=pl.col("date") + pl.duration(months=1)
+    next_month=pl.col("date").dt.offset_by("1mo")
 )
 
 # Difference between dates
@@ -512,7 +514,7 @@ df.filter(pl.col("date").dt.month().is_in([6, 7, 8]))  # Summer months
 ```python
 # Create list column
 df.with_columns(
-    items_list=pl.col("item1", "item2", "item3").to_list()
+    items_list=pl.concat_list("item1", "item2", "item3")
 )
 
 # List operations

--- a/skills/polars/references/pandas_migration.md
+++ b/skills/polars/references/pandas_migration.md
@@ -146,7 +146,7 @@ df.with_columns(
 
 | Operation | Pandas | Polars |
 |-----------|--------|--------|
-| Pivot | `df.pivot(index="a", columns="b", values="c")` | `df.pivot(values="c", index="a", columns="b")` |
+| Pivot | `df.pivot(index="a", columns="b", values="c")` | `df.pivot(values="c", index="a", on="b")` |
 | Melt | `df.melt(id_vars="id")` | `df.unpivot(index="id")` |
 
 ### I/O Operations

--- a/skills/polars/references/transformations.md
+++ b/skills/polars/references/transformations.md
@@ -23,7 +23,7 @@ result = df1.join(df2, on="id", how="left")
 **Outer Join (union):**
 ```python
 # Keep all rows from both DataFrames
-result = df1.join(df2, on="id", how="outer")
+result = df1.join(df2, on="id", how="full")
 ```
 
 **Cross Join (Cartesian product):**
@@ -232,7 +232,7 @@ df = pl.DataFrame({
 pivoted = df.pivot(
     values="sales",
     index="date",
-    columns="product"
+    on="product"
 )
 # Result:
 # date     | A   | B
@@ -255,7 +255,7 @@ df = pl.DataFrame({
 pivoted = df.pivot(
     values="sales",
     index="date",
-    columns="product",
+    on="product",
     aggregate_function="sum"  # or "mean", "max", "min", etc.
 )
 ```
@@ -273,7 +273,7 @@ df = pl.DataFrame({
 pivoted = df.pivot(
     values="sales",
     index=["region", "date"],
-    columns="product"
+    on="product"
 )
 ```
 
@@ -318,6 +318,8 @@ unpivoted = df.unpivot(
 
 ```python
 # Unpivot all columns matching pattern
+import polars.selectors as cs
+
 df = pl.DataFrame({
     "id": [1, 2],
     "sales_Q1": [100, 200],
@@ -326,10 +328,10 @@ df = pl.DataFrame({
     "revenue_Q1": [1000, 2000]
 })
 
-# Unpivot all sales columns
+# Unpivot all sales columns (on= takes column names or a selector, not pl.col)
 unpivoted = df.unpivot(
     index="id",
-    on=pl.col("^sales_.*$")
+    on=cs.starts_with("sales_")
 )
 ```
 
@@ -405,7 +407,7 @@ wide = pl.DataFrame({
 long = wide.unpivot(index="id", on=["A", "B"])
 
 # Back to wide (maybe with transformations)
-wide_again = long.pivot(values="value", index="id", columns="variable")
+wide_again = long.pivot(values="value", index="id", on="variable")
 ```
 
 ### Pattern 2: Nested to Flat
@@ -442,7 +444,7 @@ result = (
     sales
     .group_by("date", "product")
     .agg(pl.col("sales").sum())
-    .pivot(values="sales", index="date", columns="product")
+    .pivot(values="sales", index="date", on="product")
 )
 ```
 
@@ -451,26 +453,30 @@ result = (
 ### Conditional Reshaping
 
 ```python
+import polars.selectors as cs
+
 # Pivot only certain values
 df.filter(pl.col("year") >= 2020).pivot(...)
 
 # Unpivot with filtering
-df.unpivot(index="id", on=pl.col("^sales.*$"))
+df.unpivot(index="id", on=cs.starts_with("sales"))
 ```
 
 ### Multi-level Transformations
 
 ```python
 # Complex reshaping pipeline
+import polars.selectors as cs
+
 result = (
     df
-    .unpivot(index="id", on=pl.col("^Q[0-9]_.*$"))
+    .unpivot(index="id", on=cs.matches("^Q[0-9]_.*$"))
     .with_columns(
         quarter=pl.col("variable").str.extract(r"Q([0-9])", 1),
         metric=pl.col("variable").str.extract(r"Q[0-9]_(.*)", 1)
     )
     .drop("variable")
-    .pivot(values="value", index=["id", "quarter"], columns="metric")
+    .pivot(values="value", index=["id", "quarter"], on="metric")
 )
 ```
 
@@ -545,5 +551,5 @@ orders.join(customers, on="customer_id").join(products, on="product_id")
 
 ```python
 # Pivot for reporting
-sales.pivot(values="amount", index="month", columns="product")
+sales.pivot(values="amount", index="month", on="product")
 ```


### PR DESCRIPTION
- replace removed and renamed methods, and drop deprecated keywords (`how="outer"` -> `"full"`, `dtypes` -> `schema_overrides`, `NUMERIC_DTYPES` -> selectors).
- `pl.duration(months=...)` -> `dt.offset_by`; `read_excel` row/skip options belong in `read_options`; `read_json` of a literal string needs bytes.
- anchor the `pl.col` regex patterns, use selectors in `unpivot`, and add `orient="row"` where it is needed.

Run against polars 1.41.1 with deprecation warnings treated as errors.
