### PR TITLE
scikit-survival: fix metrics usage, dataset fields, and scorer setup (0.27)

### DIFF
--- a/skills/scikit-survival/SKILL.md
+++ b/skills/scikit-survival/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scikit-survival
-description: Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.
+description: 'Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.'
 license: GPL-3.0 license
 metadata:
     skill-author: K-Dense Inc.
@@ -18,7 +18,7 @@ Survival analysis aims to establish connections between covariates and the time 
 
 Use this skill when:
 - Performing survival analysis or time-to-event modeling
-- Working with censored data (right-censored, left-censored, or interval-censored)
+- Working with right-censored data (scikit-survival primarily models right-censored outcomes)
 - Fitting Cox proportional hazards models (standard or penalized)
 - Building ensemble survival models (Random Survival Forests, Gradient Boosting)
 - Training Survival Support Vector Machines
@@ -118,8 +118,9 @@ Primary metric for ranking/discrimination:
 ```python
 from sksurv.metrics import concordance_index_censored, concordance_index_ipcw
 
-# Harrell's C-index
-c_harrell = concordance_index_censored(y_test['event'], y_test['time'], risk_scores)[0]
+# Harrell's C-index (field names vary by dataset, e.g. gbsg2 uses 'cens'/'time')
+event_field, time_field = y_test.dtype.names
+c_harrell = concordance_index_censored(y_test[event_field], y_test[time_field], risk_scores)[0]
 
 # Uno's C-index (recommended)
 c_uno = concordance_index_ipcw(y_train, y_test, risk_scores)[0]
@@ -140,8 +141,13 @@ Assess both discrimination and calibration:
 
 ```python
 from sksurv.metrics import integrated_brier_score
+import numpy as np
 
-ibs = integrated_brier_score(y_train, y_test, survival_functions, times)
+# predict_survival_function returns StepFunction objects; evaluate them at `times`
+# to get a probability matrix of shape (n_samples, n_times) before scoring
+survival_functions = model.predict_survival_function(X_test)
+surv_matrix = np.asarray([[fn(t) for t in times] for fn in survival_functions])
+ibs = integrated_brier_score(y_train, y_test, surv_matrix, times)
 ```
 
 **See**: `references/evaluation-metrics.md` for comprehensive evaluation guidance, metric selection, and using scorers with cross-validation
@@ -153,8 +159,11 @@ Handle situations with multiple mutually exclusive event types:
 ```python
 from sksurv.nonparametric import cumulative_incidence_competing_risks
 
-# Estimate cumulative incidence for each event type
-time_points, cif_event1, cif_event2 = cumulative_incidence_competing_risks(y)
+# Estimate cumulative incidence for each event type.
+# Pass integer event codes (0=censored, 1..k) and exit times, not a Surv array.
+# Returns (times, cif) where cif[0] is the total and cif[1], cif[2], ... are per-risk.
+time_points, cif = cumulative_incidence_competing_risks(event_codes, time)
+cif_event1, cif_event2 = cif[1], cif[2]
 ```
 
 **Use competing risks when**:
@@ -172,14 +181,18 @@ Estimate survival functions without parametric assumptions:
 ```python
 from sksurv.nonparametric import kaplan_meier_estimator
 
-time, survival_prob = kaplan_meier_estimator(y['event'], y['time'])
+# field names vary by dataset (e.g. gbsg2 uses 'cens'/'time')
+event_field, time_field = y.dtype.names
+time, survival_prob = kaplan_meier_estimator(y[event_field], y[time_field])
 ```
 
 #### Nelson-Aalen Estimator
 ```python
 from sksurv.nonparametric import nelson_aalen_estimator
 
-time, cumulative_hazard = nelson_aalen_estimator(y['event'], y['time'])
+# field names vary by dataset (e.g. gbsg2 uses 'cens'/'time')
+event_field, time_field = y.dtype.names
+time, cumulative_hazard = nelson_aalen_estimator(y[event_field], y[time_field])
 ```
 
 ## Typical Workflows
@@ -187,14 +200,16 @@ time, cumulative_hazard = nelson_aalen_estimator(y['event'], y['time'])
 ### Workflow 1: Standard Survival Analysis
 
 ```python
-from sksurv.datasets import load_breast_cancer
+from sksurv.datasets import load_gbsg2
 from sksurv.linear_model import CoxPHSurvivalAnalysis
 from sksurv.metrics import concordance_index_ipcw
+from sksurv.preprocessing import OneHotEncoder
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 
 # 1. Load and prepare data
-X, y = load_breast_cancer()
+X, y = load_gbsg2()
+X = OneHotEncoder().fit_transform(X)  # encode categoricals before scaling
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 # 2. Preprocess
@@ -217,6 +232,7 @@ print(f"C-index: {c_index:.3f}")
 ### Workflow 2: High-Dimensional Data with Feature Selection
 
 ```python
+import numpy as np
 from sksurv.linear_model import CoxnetSurvivalAnalysis
 from sklearn.model_selection import GridSearchCV
 from sksurv.metrics import as_concordance_index_ipcw_scorer
@@ -225,19 +241,24 @@ from sksurv.metrics import as_concordance_index_ipcw_scorer
 estimator = CoxnetSurvivalAnalysis(l1_ratio=0.9)  # Lasso-like
 
 # 2. Tune regularization with cross-validation
-param_grid = {'alpha_min_ratio': [0.01, 0.001]}
-cv = GridSearchCV(estimator, param_grid,
-                  scoring=as_concordance_index_ipcw_scorer(), cv=5)
+#    as_concordance_index_ipcw_scorer wraps the estimator; use default scoring.
+#    Set tau (a truncation time within the training follow-up) so IPCW folds do
+#    not raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+param_grid = {'estimator__alpha_min_ratio': [0.01, 0.001]}
+cv = GridSearchCV(as_concordance_index_ipcw_scorer(estimator, tau=tau), param_grid, cv=5)
 cv.fit(X, y)
 
 # 3. Identify selected features
-best_model = cv.best_estimator_
+best_model = cv.best_estimator_.estimator_
 selected_features = np.where(best_model.coef_ != 0)[0]
 ```
 
 ### Workflow 3: Ensemble Method for Maximum Performance
 
 ```python
+import numpy as np
 from sksurv.ensemble import GradientBoostingSurvivalAnalysis
 from sklearn.model_selection import GridSearchCV
 
@@ -249,13 +270,18 @@ param_grid = {
 }
 
 # 2. Grid search
+#    Wrap the estimator with as_concordance_index_ipcw_scorer; use default scoring.
+#    Set tau (a truncation time within the training follow-up) so IPCW folds do
+#    not raise "time must be smaller than largest observed time point".
 gbs = GradientBoostingSurvivalAnalysis()
-cv = GridSearchCV(gbs, param_grid, cv=5,
-                  scoring=as_concordance_index_ipcw_scorer(), n_jobs=-1)
+event_field, time_field = y_train.dtype.names
+tau = np.percentile(y_train[time_field][y_train[event_field]], 80)
+param_grid = {f'estimator__{k}': v for k, v in param_grid.items()}
+cv = GridSearchCV(as_concordance_index_ipcw_scorer(gbs, tau=tau), param_grid, cv=5, n_jobs=-1)
 cv.fit(X_train, y_train)
 
 # 3. Evaluate best model
-best_model = cv.best_estimator_
+best_model = cv.best_estimator_.estimator_
 risk_scores = best_model.predict(X_test)
 c_index = concordance_index_ipcw(y_train, y_test, risk_scores)[0]
 ```
@@ -295,6 +321,7 @@ print(f"\nBest model: {best_model_name}")
 scikit-survival fully integrates with scikit-learn's ecosystem:
 
 ```python
+import numpy as np
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import cross_val_score, GridSearchCV
@@ -306,8 +333,12 @@ pipeline = Pipeline([
 ])
 
 # Use cross-validation
-scores = cross_val_score(pipeline, X, y, cv=5,
-                         scoring=as_concordance_index_ipcw_scorer())
+#    Wrap the pipeline with as_concordance_index_ipcw_scorer; use default scoring.
+#    Set tau (a truncation time within the training follow-up) so IPCW folds do
+#    not raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+scores = cross_val_score(as_concordance_index_ipcw_scorer(pipeline, tau=tau), X, y, cv=5)
 
 # Use grid search
 param_grid = {'model__alpha': [0.1, 1.0, 10.0]}
@@ -356,7 +387,7 @@ Load these reference files when detailed information is needed for specific task
 
 - **Official Documentation**: https://scikit-survival.readthedocs.io/
 - **GitHub Repository**: https://github.com/sebp/scikit-survival
-- **Built-in Datasets**: Use `sksurv.datasets` for practice datasets (GBSG2, WHAS500, veterans lung cancer, etc.)
+- **Built-in Datasets**: `sksurv.datasets` provides 9 loaders: 8 named practice datasets (`load_aids`, `load_bmt`, `load_breast_cancer`, `load_cgvhd`, `load_flchain`, `load_gbsg2`, `load_veterans_lung_cancer`, `load_whas500`) plus `load_arff_files_standardized` for reading ARFF files
 - **API Reference**: Complete list of classes and functions at https://scikit-survival.readthedocs.io/en/stable/api/index.html
 
 ## Quick Reference: Key Imports

--- a/skills/scikit-survival/references/competing-risks.md
+++ b/skills/scikit-survival/references/competing-risks.md
@@ -45,15 +45,17 @@ Estimates the cumulative incidence function for each event type.
 
 ```python
 from sksurv.nonparametric import cumulative_incidence_competing_risks
-from sksurv.datasets import load_leukemia
+from sksurv.datasets import load_bmt
 
 # Load data with competing risks
-X, y = load_leukemia()
-# y has event types: 0=censored, 1=relapse, 2=death
+X, y = load_bmt()
+# y has integer status codes: 0=censored, 1=relapse, 2=death; ftime is the exit time
 
-# Compute cumulative incidence for each event type
-# Returns: time points, CIF for event 1, CIF for event 2, ...
-time_points, cif_1, cif_2 = cumulative_incidence_competing_risks(y)
+# Compute cumulative incidence for each event type.
+# Pass integer event codes and exit times. Returns (time, cif), where
+# cif[0] is the total incidence and cif[1], cif[2], ... are per-risk.
+time_points, cif = cumulative_incidence_competing_risks(y['status'], y['ftime'])
+cif_1, cif_2 = cif[1], cif[2]
 
 # Plot cumulative incidence functions
 import matplotlib.pyplot as plt
@@ -127,16 +129,18 @@ event_types = df['event_type'].values
 from sksurv.nonparametric import cumulative_incidence_competing_risks
 import matplotlib.pyplot as plt
 
-# Split by treatment group
-mask_treatment = X['treatment'] == 'A'
-mask_control = X['treatment'] == 'B'
+# Split by treatment group (event_types: integer codes 0=censored, 1, 2, ...)
+mask_treatment = (X['treatment'] == 'A').to_numpy()
+mask_control = (X['treatment'] == 'B').to_numpy()
 
-y_treatment = y[mask_treatment]
-y_control = y[mask_control]
-
-# Compute CIF for each group
-time_trt, cif1_trt, cif2_trt = cumulative_incidence_competing_risks(y_treatment)
-time_ctl, cif1_ctl, cif2_ctl = cumulative_incidence_competing_risks(y_control)
+# Compute CIF for each group; pass integer event codes and exit times.
+# Returns (time, cif); cif[1], cif[2], ... are the per-risk incidences.
+time_trt, cif_trt = cumulative_incidence_competing_risks(
+    event_types[mask_treatment], times[mask_treatment])
+time_ctl, cif_ctl = cumulative_incidence_competing_risks(
+    event_types[mask_control], times[mask_control])
+cif1_trt, cif2_trt = cif_trt[1], cif_trt[2]
+cif1_ctl, cif2_ctl = cif_ctl[1], cif_ctl[2]
 
 # Plot comparison
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
@@ -281,8 +285,11 @@ print("=" * 60)
 print("OVERALL CUMULATIVE INCIDENCE")
 print("=" * 60)
 
-y_all = Surv.from_arrays(event=(df['event_type'] > 0), time=df['time'])
-time_points, cif_relapse, cif_death = cumulative_incidence_competing_risks(y_all)
+# Pass integer event codes (0=censored, 1=relapse, 2=death) and exit times.
+# Returns (time, cif); cif[1], cif[2] are the per-risk incidences.
+time_points, cif = cumulative_incidence_competing_risks(
+    df['event_type'].to_numpy(), df['time'].to_numpy())
+cif_relapse, cif_death = cif[1], cif[2]
 
 plt.figure(figsize=(10, 6))
 plt.step(time_points, cif_relapse, where='post', label='Relapse', linewidth=2)
@@ -304,11 +311,12 @@ print("=" * 60)
 
 for trt in ['A', 'B']:
     mask = df['treatment'] == trt
-    y_trt = Surv.from_arrays(
-        event=(df.loc[mask, 'event_type'] > 0),
-        time=df.loc[mask, 'time']
+    # Pass integer event codes and exit times; cif[1], cif[2] are per-risk.
+    time_trt, cif_trt = cumulative_incidence_competing_risks(
+        df.loc[mask, 'event_type'].to_numpy(),
+        df.loc[mask, 'time'].to_numpy()
     )
-    time_trt, cif1_trt, cif2_trt = cumulative_incidence_competing_risks(y_trt)
+    cif1_trt, cif2_trt = cif_trt[1], cif_trt[2]
     print(f"\nTreatment {trt}:")
     print(f"  5-year relapse: {cif1_trt[-1]:.2%}")
     print(f"  5-year death: {cif2_trt[-1]:.2%}")

--- a/skills/scikit-survival/references/cox-models.md
+++ b/skills/scikit-survival/references/cox-models.md
@@ -58,7 +58,7 @@ Cox model with elastic net penalty for feature selection and regularization.
 - Require sparse models
 
 ### Penalty Types
-- **Ridge (L2)**: alpha_min_ratio=1.0, l1_ratio=0
+- **Ridge-like (L2)**: small l1_ratio, e.g. 0.01 (pure l1_ratio=0 is not allowed; for true ridge use CoxPHSurvivalAnalysis(alpha=...))
   - Shrinks all coefficients
   - Good when all features are relevant
 
@@ -71,7 +71,7 @@ Cox model with elastic net penalty for feature selection and regularization.
   - Balances feature selection and grouping
 
 ### Key Parameters
-- `l1_ratio`: Balance between L1 and L2 penalty (0=Ridge, 1=Lasso)
+- `l1_ratio`: Balance between L1 and L2 penalty in the range (0.0, 1.0] (near 0=Ridge-like, 1=Lasso; exactly 0 is not allowed)
 - `alpha_min_ratio`: Ratio of smallest to largest penalty in regularization path
 - `n_alphas`: Number of alphas along regularization path
 - `fit_baseline_model`: Whether to fit unpenalized baseline model
@@ -86,7 +86,7 @@ estimator.fit(X, y)
 
 # Access regularization path
 alphas = estimator.alphas_
-coefficients_path = estimator.coef_path_
+coefficients_path = estimator.coef_  # 2D, shape (n_features, n_alphas)
 
 # Predict with specific alpha
 risk_scores = estimator.predict(X, alpha=0.1)
@@ -94,17 +94,22 @@ risk_scores = estimator.predict(X, alpha=0.1)
 
 ### Cross-Validation for Alpha Selection
 ```python
+import numpy as np
 from sklearn.model_selection import GridSearchCV
-from sksurv.metrics import concordance_index_censored
+from sksurv.metrics import as_concordance_index_ipcw_scorer
 
-# Define parameter grid
-param_grid = {'l1_ratio': [0.1, 0.5, 0.9],
-              'alpha_min_ratio': [0.01, 0.001]}
+# Define parameter grid (namespace params with estimator__ for the wrapper)
+param_grid = {'estimator__l1_ratio': [0.1, 0.5, 0.9],
+              'estimator__alpha_min_ratio': [0.01, 0.001]}
 
 # Grid search with C-index
-cv = GridSearchCV(CoxnetSurvivalAnalysis(),
+# as_concordance_index_ipcw_scorer wraps the estimator; use default scoring.
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+cv = GridSearchCV(as_concordance_index_ipcw_scorer(CoxnetSurvivalAnalysis(), tau=tau),
                   param_grid,
-                  scoring='concordance_index_ipcw',
                   cv=5)
 cv.fit(X, y)
 

--- a/skills/scikit-survival/references/data-handling.md
+++ b/skills/scikit-survival/references/data-handling.md
@@ -53,10 +53,10 @@ from sksurv.datasets import (
 X, y = load_breast_cancer()
 
 # X is pandas DataFrame with features
-# y is structured array with 'event' and 'time'
+# y is structured array with 'e.tdm' (event) and 't.tdm' (time)
 print(f"Features shape: {X.shape}")
-print(f"Number of events: {y['event'].sum()}")
-print(f"Censoring rate: {1 - y['event'].mean():.2%}")
+print(f"Number of events: {y['e.tdm'].sum()}")
+print(f"Censoring rate: {1 - y['e.tdm'].mean():.2%}")
 ```
 
 ### Loading Custom Data
@@ -224,16 +224,26 @@ selected_features = X.columns[selector.get_support()]
 
 #### Univariate Feature Selection
 
+`SelectKBest` with `f_classif` is not survival-aware: passing the structured
+survival array as the target makes it treat each unique (event, time) pair as a
+separate class, so the ranking is meaningless. Rank features by a survival-aware
+score instead, e.g. the magnitude of the coefficient from a single-feature Cox fit.
+
 ```python
-from sklearn.feature_selection import SelectKBest
-from sksurv.util import Surv
+import numpy as np
+from sksurv.linear_model import CoxPHSurvivalAnalysis
+
+# Score each feature by |coef| from a univariate Cox fit (accounts for censoring)
+scores = np.zeros(X.shape[1])
+for j, col in enumerate(X.columns):
+    cox = CoxPHSurvivalAnalysis().fit(X[[col]].to_numpy(dtype=float), y)
+    scores[j] = abs(cox.coef_[0])
 
 # Select top k features
-selector = SelectKBest(k=10)
-X_selected = selector.fit_transform(X, y)
-
-# Get selected features
-selected_features = X.columns[selector.get_support()]
+k = 10
+top_idx = np.argsort(scores)[::-1][:k]
+selected_features = X.columns[top_idx]
+X_selected = X.iloc[:, top_idx]
 ```
 
 ## Complete Preprocessing Pipeline
@@ -340,18 +350,20 @@ X_test_processed, _, _ = preprocess_survival_data(X_test, scaler=scaler, encoder
 def validate_survival_data(y):
     """Check survival data quality"""
 
+    event_field, time_field = y.dtype.names  # field names vary by dataset
+
     # Check for negative times
-    if np.any(y['time'] <= 0):
+    if np.any(y[time_field] <= 0):
         print("WARNING: Found non-positive survival times")
-        print(f"Negative times: {np.sum(y['time'] <= 0)}")
+        print(f"Negative times: {np.sum(y[time_field] <= 0)}")
 
     # Check for missing values
-    if np.any(~np.isfinite(y['time'])):
+    if np.any(~np.isfinite(y[time_field])):
         print("WARNING: Found missing survival times")
-        print(f"Missing times: {np.sum(~np.isfinite(y['time']))}")
+        print(f"Missing times: {np.sum(~np.isfinite(y[time_field]))}")
 
     # Censoring rate
-    censor_rate = 1 - y['event'].mean()
+    censor_rate = 1 - y[event_field].mean()
     print(f"Censoring rate: {censor_rate:.2%}")
 
     if censor_rate > 0.7:
@@ -359,12 +371,12 @@ def validate_survival_data(y):
         print("Consider using Uno's C-index instead of Harrell's")
 
     # Event rate
-    print(f"Number of events: {y['event'].sum()}")
-    print(f"Number of censored: {(~y['event']).sum()}")
+    print(f"Number of events: {y[event_field].sum()}")
+    print(f"Number of censored: {(~y[event_field]).sum()}")
 
     # Time statistics
-    print(f"Median time: {np.median(y['time']):.2f}")
-    print(f"Time range: [{np.min(y['time']):.2f}, {np.max(y['time']):.2f}]")
+    print(f"Median time: {np.median(y[time_field]):.2f}")
+    print(f"Time range: [{np.min(y[time_field]):.2f}, {np.max(y[time_field]):.2f}]")
 
 # Use validation
 validate_survival_data(y)

--- a/skills/scikit-survival/references/ensemble-models.md
+++ b/skills/scikit-survival/references/ensemble-models.md
@@ -83,7 +83,8 @@ from sksurv.metrics import concordance_index_censored
 # Define scoring function
 def score_survival_model(model, X, y):
     prediction = model.predict(X)
-    result = concordance_index_censored(y['event'], y['time'], prediction)
+    event_field, time_field = y.dtype.names  # field names vary by dataset
+    result = concordance_index_censored(y[event_field], y[time_field], prediction)
     return result[0]
 
 # Compute permutation importance
@@ -238,25 +239,33 @@ print(f"Used {gbs.n_estimators_} iterations")
 ### Hyperparameter Tuning
 
 ```python
+import numpy as np
 from sklearn.model_selection import GridSearchCV
+from sksurv.metrics import as_concordance_index_ipcw_scorer
 
+# Namespace params with estimator__ for the wrapper
 param_grid = {
-    'learning_rate': [0.01, 0.05, 0.1],
-    'n_estimators': [100, 200, 300],
-    'max_depth': [3, 5, 7],
-    'subsample': [0.8, 1.0]
+    'estimator__learning_rate': [0.01, 0.05, 0.1],
+    'estimator__n_estimators': [100, 200, 300],
+    'estimator__max_depth': [3, 5, 7],
+    'estimator__subsample': [0.8, 1.0]
 }
 
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+
+# as_concordance_index_ipcw_scorer wraps the estimator; use default scoring
 cv = GridSearchCV(
-    GradientBoostingSurvivalAnalysis(),
+    as_concordance_index_ipcw_scorer(GradientBoostingSurvivalAnalysis(), tau=tau),
     param_grid,
-    scoring='concordance_index_ipcw',
     cv=5,
     n_jobs=-1
 )
 cv.fit(X, y)
 
-best_model = cv.best_estimator_
+best_model = cv.best_estimator_.estimator_
 ```
 
 ## ComponentwiseGradientBoostingSurvivalAnalysis

--- a/skills/scikit-survival/references/evaluation-metrics.md
+++ b/skills/scikit-survival/references/evaluation-metrics.md
@@ -36,8 +36,9 @@ The traditional estimator, simpler but has limitations.
 ```python
 from sksurv.metrics import concordance_index_censored
 
-# Compute Harrell's C-index
-result = concordance_index_censored(y_test['event'], y_test['time'], risk_scores)
+# Compute Harrell's C-index (field names vary by dataset, e.g. gbsg2 uses 'cens'/'time')
+event_field, time_field = y_test.dtype.names
+result = concordance_index_censored(y_test[event_field], y_test[time_field], risk_scores)
 c_index = result[0]
 print(f"Harrell's C-index: {c_index:.3f}")
 ```
@@ -62,7 +63,7 @@ from sksurv.metrics import concordance_index_ipcw
 
 # Compute Uno's C-index
 # Requires training data for IPCW calculation
-c_index, concordant, discordant, tied_risk = concordance_index_ipcw(
+c_index, concordant, discordant, tied_risk, tied_time = concordance_index_ipcw(
     y_train, y_test, risk_scores
 )
 print(f"Uno's C-index: {c_index:.3f}")
@@ -86,8 +87,9 @@ print(f"Uno's C-index: {c_index:.3f}")
 ```python
 from sksurv.metrics import concordance_index_censored, concordance_index_ipcw
 
-# Harrell's C-index
-harrell = concordance_index_censored(y_test['event'], y_test['time'], risk_scores)[0]
+# Harrell's C-index (field names vary by dataset, e.g. gbsg2 uses 'cens'/'time')
+event_field, time_field = y_test.dtype.names
+harrell = concordance_index_censored(y_test[event_field], y_test[time_field], risk_scores)[0]
 
 # Uno's C-index
 uno = concordance_index_ipcw(y_train, y_test, risk_scores)[0]
@@ -198,11 +200,14 @@ print(f"Brier score at {time_point} days: {bs:.3f}")
 #### integrated_brier_score: Summary Across Time
 
 ```python
+import numpy as np
 from sksurv.metrics import integrated_brier_score
 
 # Compute integrated Brier score
 times = [365, 730, 1095, 1460, 1825]
-surv_probs = model.predict_survival_function(X_test)
+# integrated_brier_score needs a 2D array (n_samples, n_times), not StepFunction objects
+surv_funcs = model.predict_survival_function(X_test)
+surv_probs = np.asarray([[fn(t) for t in times] for fn in surv_funcs])
 
 ibs = integrated_brier_score(y_train, y_test, surv_probs, times)
 print(f"Integrated Brier Score: {ibs:.3f}")
@@ -219,17 +224,25 @@ print(f"Integrated Brier Score: {ibs:.3f}")
 Always compare against a baseline (e.g., Kaplan-Meier):
 
 ```python
+from sksurv.metrics import brier_score
 from sksurv.nonparametric import kaplan_meier_estimator
 
-# Compute Kaplan-Meier baseline
-time_km, surv_km = kaplan_meier_estimator(y_train['event'], y_train['time'])
+# Evaluation time and the model's survival probabilities at that time
+time_point = 1825  # 5 years
+surv_at_t = [fn(time_point) for fn in model.predict_survival_function(X_test)]
 
-# Predict with KM for each test subject
-surv_km_test = [surv_km[time_km <= time_point][-1] if any(time_km <= time_point) else 1.0
-                for _ in range(len(X_test))]
+# Compute Kaplan-Meier baseline (field names vary by dataset, e.g. gbsg2 'cens'/'time')
+event_field, time_field = y_train.dtype.names
+time_km, surv_km = kaplan_meier_estimator(y_train[event_field], y_train[time_field])
 
-bs_km = brier_score(y_train, y_test, surv_km_test, time_point)[1]
-bs_model = brier_score(y_train, y_test, surv_at_t, time_point)[1]
+# The KM null model is marginal: every test subject gets the same survival
+# probability at time_point (it ignores covariates).
+km_prob = surv_km[time_km <= time_point][-1] if any(time_km <= time_point) else 1.0
+surv_km_test = [km_prob for _ in range(len(X_test))]
+
+# brier_score returns (times, scores); with one time point take the single scalar
+bs_km = brier_score(y_train, y_test, surv_km_test, time_point)[1][0]
+bs_model = brier_score(y_train, y_test, surv_at_t, time_point)[1][0]
 
 print(f"Kaplan-Meier Brier Score: {bs_km:.3f}")
 print(f"Model Brier Score: {bs_model:.3f}")
@@ -241,36 +254,46 @@ print(f"Improvement: {(bs_km - bs_model) / bs_km * 100:.1f}%")
 ### Concordance Index Scorer
 
 ```python
+import numpy as np
 from sklearn.model_selection import cross_val_score
 from sksurv.metrics import as_concordance_index_ipcw_scorer
 
-# Create scorer
-scorer = as_concordance_index_ipcw_scorer()
+# Wrap the estimator (as_concordance_index_ipcw_scorer is an estimator wrapper,
+# not a scorer factory); use default scoring. Set tau (a truncation time within
+# the training follow-up) so IPCW folds do not raise "time must be smaller than
+# largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+wrapped = as_concordance_index_ipcw_scorer(model, tau=tau)
 
 # Perform cross-validation
-scores = cross_val_score(model, X, y, cv=5, scoring=scorer)
+scores = cross_val_score(wrapped, X, y, cv=5)
 print(f"Mean C-index: {scores.mean():.3f} (±{scores.std():.3f})")
 ```
 
 ### Integrated Brier Score Scorer
 
 ```python
+import numpy as np
 from sksurv.metrics import as_integrated_brier_score_scorer
+from sksurv.linear_model import CoxPHSurvivalAnalysis
 
-# Define time points for evaluation
-times = np.percentile(y['time'][y['event']], [25, 50, 75])
+# Define time points for evaluation (field names vary by dataset, e.g. gbsg2 'cens'/'time')
+event_field, time_field = y.dtype.names
+times = np.percentile(y[time_field][y[event_field]], [25, 50, 75])
 
-# Create scorer
-scorer = as_integrated_brier_score_scorer(times)
+# Wrap the estimator (signature is (estimator, times)); use default scoring
+wrapped = as_integrated_brier_score_scorer(CoxPHSurvivalAnalysis(), times)
 
 # Perform cross-validation
-scores = cross_val_score(model, X, y, cv=5, scoring=scorer)
+scores = cross_val_score(wrapped, X, y, cv=5)
 print(f"Mean IBS: {scores.mean():.3f} (±{scores.std():.3f})")
 ```
 
 ## Model Selection with GridSearchCV
 
 ```python
+import numpy as np
 from sklearn.model_selection import GridSearchCV
 from sksurv.ensemble import RandomSurvivalForest
 from sksurv.metrics import as_concordance_index_ipcw_scorer
@@ -282,14 +305,18 @@ param_grid = {
     'max_depth': [None, 10, 20]
 }
 
-# Create scorer
-scorer = as_concordance_index_ipcw_scorer()
+# Wrap the estimator (the scorer wrapper, not scoring=); namespace params with estimator__
+param_grid = {f'estimator__{k}': v for k, v in param_grid.items()}
+
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
 
 # Perform grid search
 cv = GridSearchCV(
-    RandomSurvivalForest(random_state=42),
+    as_concordance_index_ipcw_scorer(RandomSurvivalForest(random_state=42), tau=tau),
     param_grid,
-    scoring=scorer,
     cv=5,
     n_jobs=-1
 )
@@ -317,17 +344,19 @@ def evaluate_survival_model(model, X_train, X_test, y_train, y_test):
     # Get predictions
     risk_scores = model.predict(X_test)
     surv_funcs = model.predict_survival_function(X_test)
+    event_field, time_field = y_test.dtype.names
 
     # 1. Concordance Index (both versions)
-    c_harrell = concordance_index_censored(y_test['event'], y_test['time'], risk_scores)[0]
+    c_harrell = concordance_index_censored(y_test[event_field], y_test[time_field], risk_scores)[0]
     c_uno = concordance_index_ipcw(y_train, y_test, risk_scores)[0]
 
     # 2. Time-dependent AUC
-    times = np.percentile(y_test['time'][y_test['event']], [25, 50, 75])
+    times = np.percentile(y_test[time_field][y_test[event_field]], [25, 50, 75])
     auc, mean_auc = cumulative_dynamic_auc(y_train, y_test, risk_scores, times)
 
     # 3. Integrated Brier Score
-    ibs = integrated_brier_score(y_train, y_test, surv_funcs, times)
+    surv_probs = np.asarray([[fn(t) for t in times] for fn in surv_funcs])
+    ibs = integrated_brier_score(y_train, y_test, surv_probs, times)
 
     # Print results
     print("=" * 50)

--- a/skills/scikit-survival/references/svm-models.md
+++ b/skills/scikit-survival/references/svm-models.md
@@ -38,7 +38,7 @@ Linear survival SVM optimized for speed using coordinate descent.
   - Higher = more regularization
 - `rank_ratio`: Trade-off between ranking and regression (default: 1.0)
 - `max_iter`: Maximum iterations (default: 20)
-- `tol`: Tolerance for stopping criterion (default: 1e-5)
+- `tol`: Tolerance for stopping criterion (default: None)
 
 ```python
 from sksurv.svm import FastSurvivalSVM
@@ -80,10 +80,11 @@ Kernel survival SVM for non-linear relationships.
 from sksurv.svm import FastKernelSurvivalSVM
 
 # Fit RBF kernel survival SVM
+# gamma must be a float in [0, inf) or None (no 'scale'/'auto' strings)
 estimator = FastKernelSurvivalSVM(
     alpha=1.0,
     kernel='rbf',
-    gamma='scale',
+    gamma=0.1,
     max_iter=50,
     random_state=42
 )
@@ -104,13 +105,16 @@ Survival SVM using hinge loss, more similar to classification SVM.
 
 **Key Parameters:**
 - `alpha`: Regularization parameter
-- `fit_intercept`: Whether to fit intercept term (default: False)
+- `solver`: Optimization solver (e.g. 'ecos')
+- `kernel`: Kernel function
+- `pairs`: Which comparable pairs to use
+- `max_iter`: Maximum iterations
 
 ```python
 from sksurv.svm import HingeLossSurvivalSVM
 
 # Fit hinge loss SVM
-estimator = HingeLossSurvivalSVM(alpha=1.0, fit_intercept=False, random_state=42)
+estimator = HingeLossSurvivalSVM(alpha=1.0)
 estimator.fit(X, y)
 
 # Predict risk scores
@@ -154,7 +158,7 @@ Survival analysis using minimizing Lipschitz constant approach.
 from sksurv.svm import MinlipSurvivalAnalysis
 
 # Fit Minlip model
-estimator = MinlipSurvivalAnalysis(alpha=1.0, random_state=42)
+estimator = MinlipSurvivalAnalysis(alpha=1.0)
 estimator.fit(X, y)
 
 # Predict
@@ -166,44 +170,58 @@ risk_scores = estimator.predict(X_test)
 ### Tuning Alpha (Regularization)
 
 ```python
+import numpy as np
 from sklearn.model_selection import GridSearchCV
 from sksurv.metrics import as_concordance_index_ipcw_scorer
 
-# Define parameter grid
+# Define parameter grid (namespace with estimator__ for the wrapper)
 param_grid = {
-    'alpha': [0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
+    'estimator__alpha': [0.1, 0.5, 1.0, 5.0, 10.0, 50.0]
 }
 
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+
 # Grid search
+# as_concordance_index_ipcw_scorer wraps the estimator; use default scoring
 cv = GridSearchCV(
-    FastSurvivalSVM(),
+    as_concordance_index_ipcw_scorer(FastSurvivalSVM(), tau=tau),
     param_grid,
-    scoring=as_concordance_index_ipcw_scorer(),
     cv=5,
     n_jobs=-1
 )
 cv.fit(X, y)
 
-print(f"Best alpha: {cv.best_params_['alpha']}")
+print(f"Best alpha: {cv.best_params_['estimator__alpha']}")
 print(f"Best C-index: {cv.best_score_:.3f}")
 ```
 
 ### Tuning Kernel Parameters
 
 ```python
+import numpy as np
 from sklearn.model_selection import GridSearchCV
+from sksurv.metrics import as_concordance_index_ipcw_scorer
 
-# Define parameter grid for kernel SVM
+# Define parameter grid for kernel SVM (namespace with estimator__ for the wrapper)
+# gamma must be a float in [0, inf) or None (no 'scale'/'auto' strings)
 param_grid = {
-    'alpha': [0.1, 1.0, 10.0],
-    'gamma': ['scale', 'auto', 0.001, 0.01, 0.1, 1.0]
+    'estimator__alpha': [0.1, 1.0, 10.0],
+    'estimator__gamma': [None, 0.001, 0.01, 0.1, 1.0]
 }
 
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+
 # Grid search
+# as_concordance_index_ipcw_scorer wraps the estimator; use default scoring
 cv = GridSearchCV(
-    FastKernelSurvivalSVM(kernel='rbf'),
+    as_concordance_index_ipcw_scorer(FastKernelSurvivalSVM(kernel='rbf'), tau=tau),
     param_grid,
-    scoring=as_concordance_index_ipcw_scorer(),
     cv=5,
     n_jobs=-1
 )
@@ -255,6 +273,7 @@ estimator.fit(X_combined, y)
 ### Example 1: Linear SVM with Cross-Validation
 
 ```python
+import numpy as np
 from sksurv.svm import FastSurvivalSVM
 from sklearn.model_selection import cross_val_score
 from sksurv.metrics import as_concordance_index_ipcw_scorer
@@ -267,11 +286,16 @@ X_scaled = scaler.fit_transform(X)
 # Create model
 svm = FastSurvivalSVM(alpha=1.0, max_iter=100, random_state=42)
 
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y.dtype.names
+tau = np.percentile(y[time_field][y[event_field]], 80)
+
 # Cross-validation
+# Wrap the estimator (the scorer wrapper, not scoring=); use default scoring
 scores = cross_val_score(
-    svm, X_scaled, y,
+    as_concordance_index_ipcw_scorer(svm, tau=tau), X_scaled, y,
     cv=5,
-    scoring=as_concordance_index_ipcw_scorer(),
     n_jobs=-1
 )
 
@@ -319,6 +343,7 @@ print(f"\nBest kernel: {best_kernel} (C-index = {results[best_kernel]:.3f})")
 ### Example 3: Full Pipeline with Hyperparameter Tuning
 
 ```python
+import numpy as np
 from sksurv.svm import FastKernelSurvivalSVM
 from sklearn.model_selection import GridSearchCV, train_test_split
 from sklearn.pipeline import Pipeline
@@ -335,16 +360,22 @@ pipeline = Pipeline([
 ])
 
 # Define parameter grid
+# The scorer wrapper nests the pipeline under estimator__; gamma must be float or None
 param_grid = {
-    'svm__alpha': [0.1, 1.0, 10.0],
-    'svm__gamma': ['scale', 0.01, 0.1, 1.0]
+    'estimator__svm__alpha': [0.1, 1.0, 10.0],
+    'estimator__svm__gamma': [None, 0.01, 0.1, 1.0]
 }
 
+# Set tau (a truncation time within the training follow-up) so IPCW folds do not
+# raise "time must be smaller than largest observed time point".
+event_field, time_field = y_train.dtype.names
+tau = np.percentile(y_train[time_field][y_train[event_field]], 80)
+
 # Grid search
+# as_concordance_index_ipcw_scorer wraps the pipeline; use default scoring
 cv = GridSearchCV(
-    pipeline,
+    as_concordance_index_ipcw_scorer(pipeline, tau=tau),
     param_grid,
-    scoring=as_concordance_index_ipcw_scorer(),
     cv=5,
     n_jobs=-1,
     verbose=1
@@ -352,7 +383,7 @@ cv = GridSearchCV(
 cv.fit(X_train, y_train)
 
 # Best model
-best_model = cv.best_estimator_
+best_model = cv.best_estimator_.estimator_
 print(f"Best parameters: {cv.best_params_}")
 print(f"Best CV C-index: {cv.best_score_:.3f}")
 


### PR DESCRIPTION
- use the field-agnostic `event_field, time_field = y.dtype.names` idiom; the hardcoded `'event'` field crashes on the built-in datasets, gbsg2 included.
- `concordance_index_ipcw` returns five values, and `integrated_brier_score` needs a 2-D estimate array.
- set `tau` on the IPCW scorer wrappers so cross-validation does not fail on some datasets.

Run on the built-in datasets with scikit-survival 0.27.0 and scikit-learn 1.8.0.
