### PR TITLE
aeon: fix removed/renamed 1.4.0 APIs and broken examples across the skill

### DIFF
--- a/skills/aeon/SKILL.md
+++ b/skills/aeon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aeon
-description: This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.
+description: 'This skill should be used for time series machine learning tasks including classification, regression, clustering, forecasting, anomaly detection, segmentation, and similarity search. Use when working with temporal data, sequential patterns, or time-indexed observations requiring specialized algorithms beyond standard ML approaches. Particularly suited for univariate and multivariate time series analysis with scikit-learn compatible APIs.'
 license: BSD-3-Clause license
 metadata:
     skill-author: K-Dense Inc.
@@ -96,11 +96,11 @@ Predict future time series values. See `references/forecasting.md` for forecaste
 
 **Quick Start:**
 ```python
-from aeon.forecasting.arima import ARIMA
+from aeon.forecasting.stats import ARIMA
 
-forecaster = ARIMA(order=(1, 1, 1))
-forecaster.fit(y_train)
-y_pred = forecaster.predict(fh=[1, 2, 3, 4, 5])
+forecaster = ARIMA(p=1, d=1, q=1)
+# Multi-step forecast (horizon of 5)
+y_pred = forecaster.iterative_forecast(y_train, prediction_horizon=5)
 ```
 
 ### 5. Anomaly Detection
@@ -109,7 +109,10 @@ Identify unusual patterns or outliers. See `references/anomaly_detection.md` for
 
 **Quick Start:**
 ```python
-from aeon.anomaly_detection import STOMP
+# STOMP needs the optional 'stumpy' and 'psutil' soft dependencies
+# (pip install stumpy psutil, or pip install aeon[all_extras])
+from aeon.anomaly_detection.series.distance_based import STOMP
+import numpy as np
 
 detector = STOMP(window_size=50)
 anomaly_scores = detector.fit_predict(y)
@@ -137,11 +140,11 @@ Find similar patterns within or across time series. See `references/similarity_s
 
 **Quick Start:**
 ```python
-from aeon.similarity_search import StompMotif
+from aeon.similarity_search.series import StompMotif
 
 # Find recurring patterns
-motif_finder = StompMotif(window_size=50, k=3)
-motifs = motif_finder.fit_predict(y)
+motif_finder = StompMotif(length=50)
+motifs = motif_finder.fit_predict(y, k=3)
 ```
 
 ## Feature Extraction and Transformations
@@ -150,9 +153,9 @@ Transform time series for feature engineering. See `references/transformations.m
 
 **ROCKET Features:**
 ```python
-from aeon.transformations.collection.convolution_based import RocketTransformer
+from aeon.transformations.collection.convolution_based import Rocket
 
-rocket = RocketTransformer()
+rocket = Rocket()
 X_features = rocket.fit_transform(X_train)
 
 # Use features with any sklearn classifier
@@ -215,7 +218,7 @@ Neural architectures for time series. See `references/networks.md`.
 - Recurrent: `RecurrentNetwork`, `TCNNetwork`
 - Autoencoders: `AEFCNClusterer`, `AEResNetClusterer`
 
-**Usage:**
+**Usage:** (deep-learning estimators require the optional `tensorflow` soft dependency: `pip install aeon[dl]`)
 ```python
 from aeon.classification.deep_learning import InceptionTimeClassifier
 
@@ -228,7 +231,7 @@ predictions = clf.predict(X_test)
 
 Load standard benchmarks and evaluate performance. See `references/datasets_benchmarking.md`.
 
-**Load Datasets:**
+**Load Datasets:** (in aeon 1.4.0 `load_classification`/`load_regression` are deprecated; their `load_equal_length` and `load_no_missing` arguments default to `True` now but will default to `False` in 1.5.0. Pass them explicitly if you need stable behavior across versions.)
 ```python
 from aeon.datasets import load_classification, load_regression
 
@@ -241,10 +244,10 @@ X_train, y_train = load_regression("Covid3Month", split="train")
 
 **Benchmarking:**
 ```python
-from aeon.benchmarking import get_estimator_results
+from aeon.benchmarking.results_loaders import get_estimator_results
 
 # Compare with published results
-published = get_estimator_results("ROCKET", "GunPoint")
+published = get_estimator_results("ROCKET", ["GunPoint"])  # nested: published["ROCKET"]["GunPoint"]
 ```
 
 ## Common Workflows
@@ -268,11 +271,11 @@ accuracy = pipeline.score(X_test, y_test)
 ### Feature Extraction + Traditional ML
 
 ```python
-from aeon.transformations.collection import RocketTransformer
+from aeon.transformations.collection.convolution_based import Rocket
 from sklearn.ensemble import GradientBoostingClassifier
 
 # Extract features
-rocket = RocketTransformer()
+rocket = Rocket()
 X_train_features = rocket.fit_transform(X_train)
 X_test_features = rocket.transform(X_test)
 
@@ -285,8 +288,9 @@ predictions = clf.predict(X_test_features)
 ### Anomaly Detection with Visualization
 
 ```python
-from aeon.anomaly_detection import STOMP
+from aeon.anomaly_detection.series.distance_based import STOMP
 import matplotlib.pyplot as plt
+import numpy as np
 
 detector = STOMP(window_size=50)
 scores = detector.fit_predict(y)

--- a/skills/aeon/references/anomaly_detection.md
+++ b/skills/aeon/references/anomaly_detection.md
@@ -64,7 +64,7 @@ Analyze statistical distributions:
 
 ### Isolation-Based Methods
 
-Use isolation principles:
+Use isolation principles (import these from `aeon.anomaly_detection.series.outlier_detection`):
 
 - `IsolationForest` - Random forest-based isolation
   - Anomalies easier to isolate than normal points
@@ -87,7 +87,8 @@ Use isolation principles:
 ## Quick Start
 
 ```python
-from aeon.anomaly_detection import STOMP
+# STOMP requires the optional 'stumpy' soft dependency (pip install stumpy)
+from aeon.anomaly_detection.series.distance_based import STOMP
 import numpy as np
 
 # Create time series with anomaly

--- a/skills/aeon/references/classification.md
+++ b/skills/aeon/references/classification.md
@@ -116,7 +116,7 @@ Handle ordered class labels:
 Build custom pipelines and ensembles:
 
 - `ClassifierPipeline` - Chain transformers with classifiers
-- `WeightedEnsembleClassifier` - Weighted combination of classifiers
+- `ClassifierEnsemble` - Weighted combination of classifiers
 - `SklearnClassifierWrapper` - Adapt sklearn classifiers for time series
 
 ## Quick Start

--- a/skills/aeon/references/clustering.md
+++ b/skills/aeon/references/clustering.md
@@ -73,7 +73,7 @@ Build custom clustering pipelines:
 Compute cluster centers for time series:
 
 - `mean_average` - Arithmetic mean
-- `ba_average` - Barycentric averaging with DTW
+- `elastic_barycenter_average` - Barycentric averaging with DTW
 - `kasba_average` - Shift-invariant averaging
 - `shift_invariant_average` - General shift-invariant method
 

--- a/skills/aeon/references/datasets_benchmarking.md
+++ b/skills/aeon/references/datasets_benchmarking.md
@@ -4,6 +4,8 @@ Aeon provides comprehensive tools for loading datasets and benchmarking time ser
 
 ## Dataset Loading
 
+> Note: in aeon 1.4.0 `load_classification` and `load_regression` are deprecated. They still return data, but their `load_equal_length` and `load_no_missing` arguments default to `True` today and will default to `False` in version 1.5.0. Pass them explicitly if you need stable behavior across versions.
+
 ### Task-Specific Loaders
 
 **Classification Datasets**:
@@ -35,7 +37,7 @@ download_all_regression()  # Downloads Monash TSER archive
 from aeon.datasets import load_forecasting
 
 # Load from forecastingdata.org
-y, X = load_forecasting("airline", return_X_y=True)
+data = load_forecasting("m1_yearly_dataset")  # returns the loaded data; name must match the forecastingdata.org archive
 ```
 
 **Anomaly Detection Datasets**:
@@ -86,17 +88,12 @@ X, y = load_from_timeeval_csv_file("path/to/timeeval.csv")
 
 **Write to .ts format**:
 ```python
-from aeon.datasets import write_to_ts_file
+from aeon.datasets import save_to_ts_file
 
-write_to_ts_file(X, "output.ts", y=y, problem_name="MyDataset")
+save_to_ts_file(X, y=y, path=".", problem_name="MyDataset")
 ```
 
-**Write to ARFF format**:
-```python
-from aeon.datasets import write_to_arff_file
-
-write_to_arff_file(X, "output.arff", y=y)
-```
+**Write to ARFF format**: aeon 1.4 has no ARFF writer; use `save_to_ts_file` (the `.ts` format) to round-trip aeon datasets.
 
 ## Built-in Datasets
 
@@ -128,9 +125,10 @@ Get information about datasets:
 ```python
 from aeon.datasets import get_dataset_meta_data
 
-metadata = get_dataset_meta_data("GunPoint")
+# data_names must be list-like; returns a pandas DataFrame (one row per dataset)
+metadata = get_dataset_meta_data(["GunPoint"])
 print(metadata)
-# {'n_train': 50, 'n_test': 150, 'length': 150, 'n_classes': 2, ...}
+# columns: ['Dataset', 'TrainSize', 'TestSize', 'Length', 'NumberClasses', 'Type', 'Channels']
 ```
 
 ## Benchmarking Tools
@@ -140,16 +138,18 @@ print(metadata)
 Access pre-computed benchmark results:
 
 ```python
-from aeon.benchmarking import get_estimator_results
+from aeon.benchmarking.results_loaders import get_estimator_results
 
 # Get results for specific algorithm on dataset
 results = get_estimator_results(
-    estimator_name="ROCKET",
-    dataset_name="GunPoint"
+    estimators="ROCKET",
+    datasets=["GunPoint"]
 )
+# nested dict: results["ROCKET"]["GunPoint"]
 
-# Get all available estimators for a dataset
-estimators = get_available_estimators("GunPoint")
+# List the estimators that have published results
+from aeon.benchmarking.results_loaders import get_available_estimators
+estimators = get_available_estimators(task="classification")
 ```
 
 ### Resampling Strategies
@@ -157,13 +157,13 @@ estimators = get_available_estimators("GunPoint")
 Create reproducible train/test splits:
 
 ```python
-from aeon.benchmarking import stratified_resample
+from aeon.benchmarking.resampling import stratified_resample_data
 
-# Stratified resampling maintaining class distribution
-X_train, X_test, y_train, y_test = stratified_resample(
-    X, y,
-    random_state=42,
-    test_size=0.3
+# Stratified resampling of an existing train/test split (preserves class
+# proportions and the original split sizes); useful for benchmarking repeats
+X_train2, y_train2, X_test2, y_test2 = stratified_resample_data(
+    X_train, y_train, X_test, y_test,
+    random_state=42
 )
 ```
 
@@ -189,10 +189,10 @@ auc = range_roc_auc_score(y_true, y_scores)
 
 **Clustering Metrics**:
 ```python
-from aeon.benchmarking.metrics.clustering import clustering_accuracy
+from aeon.benchmarking.metrics.clustering import clustering_accuracy_score
 
 # Clustering accuracy with label matching
-accuracy = clustering_accuracy(y_true, y_pred)
+accuracy = clustering_accuracy_score(y_true, y_pred)
 ```
 
 **Segmentation Metrics**:
@@ -214,16 +214,17 @@ hausdorff_err = hausdorff_error(y_true, y_pred)
 Post-hoc analysis for algorithm comparison:
 
 ```python
-from aeon.benchmarking import (
+from aeon.benchmarking.stats import (
     nemenyi_test,
     wilcoxon_test
 )
 
-# Nemenyi test for multiple algorithms
-results = nemenyi_test(scores_matrix, alpha=0.05)
+# Pairwise Wilcoxon signed-rank p-value matrix
+# results: 2D array (n_datasets x n_estimators); labels: estimator names
+p_values = wilcoxon_test(results, labels)
 
-# Pairwise Wilcoxon signed-rank test
-stat, p_value = wilcoxon_test(scores_alg1, scores_alg2)
+# nemenyi_test returns a clique matrix: cliques[i, j] is True if estimators i and j are not significantly different
+cliques = nemenyi_test(ordered_avg_ranks, n_datasets, alpha=0.05)
 ```
 
 ## Benchmark Collections
@@ -243,7 +244,7 @@ X_train, y_train = load_classification("Chinatown", split="train")
 
 ```python
 # Load forecasting datasets
-y = load_forecasting("nn5_daily", return_X_y=False)
+y = load_forecasting("nn5_daily")  # name must match the forecastingdata.org archive
 ```
 
 ### Published Benchmark Results
@@ -261,7 +262,7 @@ Complete benchmarking workflow:
 ```python
 from aeon.datasets import load_classification
 from aeon.classification.convolution_based import RocketClassifier
-from aeon.benchmarking import get_estimator_results
+from aeon.benchmarking.results_loaders import get_estimator_results
 from sklearn.metrics import accuracy_score
 import numpy as np
 
@@ -280,8 +281,8 @@ accuracy = accuracy_score(y_test, y_pred)
 print(f"Accuracy: {accuracy:.4f}")
 
 # Compare with published results
-published = get_estimator_results("ROCKET", dataset_name)
-print(f"Published ROCKET accuracy: {published['accuracy']:.4f}")
+published = get_estimator_results("ROCKET", [dataset_name])
+print(f"Published ROCKET accuracy: {published['ROCKET'][dataset_name]:.4f}")
 ```
 
 ## Best Practices
@@ -306,7 +307,8 @@ Ensure reproducibility:
 
 ```python
 clf = RocketClassifier(random_state=42)
-results = stratified_resample(X, y, random_state=42)
+# reproducible resampling of a train/test split (see Resampling Strategies above):
+# stratified_resample_data(X_train, y_train, X_test, y_test, random_state=42)
 ```
 
 ### 3. Report Multiple Metrics
@@ -357,14 +359,16 @@ print(f"Your model: {accuracy:.4f}")
 Test if improvements are statistically significant:
 
 ```python
-from aeon.benchmarking import wilcoxon_test
+from aeon.benchmarking.stats import wilcoxon_test
+import numpy as np
 
-# Run on multiple datasets
-accuracies_alg1 = [0.85, 0.92, 0.78, 0.88]
-accuracies_alg2 = [0.83, 0.90, 0.76, 0.86]
+# results: rows = datasets, columns = estimators (e.g. accuracies)
+results = np.array([[0.85, 0.83], [0.92, 0.90], [0.78, 0.76], [0.88, 0.86]])
+labels = ["alg1", "alg2"]
 
-stat, p_value = wilcoxon_test(accuracies_alg1, accuracies_alg2)
-if p_value < 0.05:
+# Returns a pairwise p-value matrix (estimators x estimators)
+p_values = wilcoxon_test(results, labels)
+if p_values[0, 1] < 0.05:
     print("Difference is statistically significant")
 ```
 
@@ -373,15 +377,14 @@ if p_value < 0.05:
 Find datasets matching criteria:
 
 ```python
-# List all available classification datasets
-from aeon.datasets import get_available_datasets
+# Named collections of classification dataset names
+from aeon.datasets import tsc_datasets
 
-datasets = get_available_datasets("classification")
+datasets = tsc_datasets.UCR2019  # univariate archive (also: UEA, multivariate, ...)
 print(f"Found {len(datasets)} classification datasets")
 
-# Filter by properties
-univariate_datasets = [
-    d for d in datasets
-    if get_dataset_meta_data(d)['n_channels'] == 1
-]
+# Filter by properties: get_dataset_meta_data takes a list-like and returns a
+# DataFrame with a 'Channels' column (1 == univariate)
+meta = get_dataset_meta_data(datasets)
+univariate_datasets = meta[meta['Channels'] == 1]['Dataset'].tolist()
 ```

--- a/skills/aeon/references/distances.md
+++ b/skills/aeon/references/distances.md
@@ -75,8 +75,9 @@ from aeon.distances import dtw_cost_matrix, dtw_alignment_path
 cost_matrix = dtw_cost_matrix(x, y)
 
 # Get optimal alignment path
-path = dtw_alignment_path(x, y)
-# Returns indices: [(0,0), (1,1), (2,1), (2,2), ...]
+path, distance = dtw_alignment_path(x, y)
+# Returns a 2-tuple: (list of index pairs, distance)
+# path -> [(0,0), (1,1), (2,1), (2,2), ...]; distance -> float
 ```
 
 ### Using with Estimators
@@ -103,8 +104,8 @@ Limit warping path deviation (improves speed and prevents pathological warping):
 # Sakoe-Chiba band: window as fraction of series length
 dtw_distance(x, y, window=0.1)  # Allow 10% deviation
 
-# Itakura parallelogram: slopes constrain path
-dtw_distance(x, y, itakura_max_slope=2.0)
+# Itakura parallelogram: slopes constrain path (value must be in (0, 1])
+dtw_distance(x, y, itakura_max_slope=0.5)
 ```
 
 ### Normalization
@@ -112,8 +113,10 @@ dtw_distance(x, y, itakura_max_slope=2.0)
 Control whether to z-normalize series before distance computation:
 
 ```python
-# Most elastic distances support normalization
-distance = dtw_distance(x, y, normalize=True)
+# aeon distance functions have no `normalize` argument; z-normalize the series yourself first
+x_z = (x - x.mean()) / x.std()
+y_z = (y - y.mean()) / y.std()
+distance = dtw_distance(x_z, y_z)
 ```
 
 ### Distance-Specific Parameters

--- a/skills/aeon/references/forecasting.md
+++ b/skills/aeon/references/forecasting.md
@@ -7,7 +7,7 @@ Aeon provides forecasting algorithms for predicting future time series values.
 Simple forecasting strategies for comparison:
 
 - `NaiveForecaster` - Multiple strategies: last value, mean, seasonal naive
-  - Parameters: `strategy` ("last", "mean", "seasonal"), `sp` (seasonal period)
+  - Parameters: `strategy` ("last", "mean", "seasonal_last"), `seasonal_period`
   - **Use when**: Establishing baselines or simple patterns
 
 ## Statistical Models
@@ -21,7 +21,7 @@ Classical time series forecasting methods:
 
 ### Exponential Smoothing
 - `ETS` - Error-Trend-Seasonal decomposition
-  - Parameters: `error`, `trend`, `seasonal` types
+  - Parameters: `error_type`, `trend_type`, `seasonality_type` (plus `seasonal_period`)
   - **Use when**: Trend and seasonal patterns present
 
 ### Threshold Autoregressive
@@ -31,7 +31,7 @@ Classical time series forecasting methods:
 
 ### Theta Method
 - `Theta` - Classical Theta forecasting
-  - Parameters: `theta`, `weights` for decomposition
+  - Parameters: `theta`, `weight` for decomposition
   - **Use when**: Simple but effective baseline needed
 
 ### Time-Varying Parameter
@@ -61,8 +61,8 @@ Apply regression to lagged features:
 ## Quick Start
 
 ```python
-from aeon.forecasting.naive import NaiveForecaster
-from aeon.forecasting.arima import ARIMA
+from aeon.forecasting import NaiveForecaster
+from aeon.forecasting.stats import ARIMA
 import numpy as np
 
 # Create time series
@@ -71,12 +71,12 @@ y = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 # Naive baseline
 naive = NaiveForecaster(strategy="last")
 naive.fit(y)
-forecast_naive = naive.predict(fh=[1, 2, 3])
+forecast_naive = naive.iterative_forecast(y, prediction_horizon=3)
 
 # ARIMA model
-arima = ARIMA(order=(1, 1, 1))
-arima.fit(y)
-forecast_arima = arima.predict(fh=[1, 2, 3])
+arima = ARIMA(p=1, d=1, q=1)
+# Multi-step forecast (next 3 steps)
+forecast_arima = arima.iterative_forecast(y, prediction_horizon=3)
 ```
 
 ## Forecasting Horizon
@@ -84,17 +84,15 @@ forecast_arima = arima.predict(fh=[1, 2, 3])
 The forecasting horizon (`fh`) specifies which future time points to predict:
 
 ```python
-# Relative horizon (next 3 steps)
-fh = [1, 2, 3]
-
-# Absolute horizon (specific time indices)
-from aeon.forecasting.base import ForecastingHorizon
-fh = ForecastingHorizon([11, 12, 13], is_relative=False)
+# aeon forecasters take an integer prediction horizon (number of future steps ahead)
+prediction_horizon = 3
+# multi-step forecast with an iterative forecaster:
+# y_pred = forecaster.iterative_forecast(y, prediction_horizon=prediction_horizon)
 ```
 
 ## Model Selection
 
-- **Baseline**: NaiveForecaster with seasonal strategy
+- **Baseline**: NaiveForecaster with seasonal_last strategy
 - **Linear patterns**: ARIMA
 - **Trend + seasonality**: ETS
 - **Regime changes**: TAR, AutoTAR
@@ -108,7 +106,7 @@ fh = ForecastingHorizon([11, 12, 13], is_relative=False)
 Use standard forecasting metrics:
 
 ```python
-from aeon.performance_metrics.forecasting import (
+from sklearn.metrics import (
     mean_absolute_error,
     mean_squared_error,
     mean_absolute_percentage_error
@@ -126,10 +124,10 @@ Many forecasters support exogenous features:
 
 ```python
 # Train with exogenous variables
-forecaster.fit(y, X=X_train)
+forecaster.fit(y, exog=X_train)
 
-# Predict requires future exogenous values
-y_pred = forecaster.predict(fh=[1, 2, 3], X=X_test)
+# Multi-step forecast with future exogenous values
+y_pred = forecaster.iterative_forecast(y, prediction_horizon=3, exog=X_test)
 ```
 
 ## Base Classes

--- a/skills/aeon/references/regression.md
+++ b/skills/aeon/references/regression.md
@@ -25,7 +25,7 @@ Neural architectures for end-to-end temporal regression:
 - `RecurrentRegressor` - RNN/LSTM/GRU variants
 - `MLPRegressor` - Multi-layer perceptron
 - `EncoderRegressor` - Generic encoder wrapper
-- `LITERegressor` - Lightweight inception time ensemble
+- `LITETimeRegressor` - Lightweight inception time ensemble
 - `DisjointCNNRegressor` - Specialized CNN architecture
 
 **Use when**: Large datasets, complex patterns, or need feature learning.

--- a/skills/aeon/references/segmentation.md
+++ b/skills/aeon/references/segmentation.md
@@ -7,7 +7,7 @@ Aeon provides algorithms to partition time series into regions with distinct cha
 ### Binary Segmentation
 - `BinSegmenter` - Recursive binary segmentation
   - Iteratively splits series at most significant change points
-  - Parameters: `n_segments`, `cost_function`
+  - Parameters: `n_cps` (number of change points), `model` (cost model, e.g. `'l2'`)
   - **Use when**: Known number of segments, hierarchical structure
 
 ### Classification-Based
@@ -85,7 +85,7 @@ Segmenters return change point indices:
 
 - **Speed priority**: FLUSSSegmenter, BinSegmenter
 - **Accuracy priority**: ClaSPSegmenter, HMMSegmenter
-- **Known segment count**: BinSegmenter with n_segments parameter
+- **Known segment count**: BinSegmenter with n_cps parameter
 - **Unknown segment count**: ClaSPSegmenter, InformationGainSegmenter
 - **Pattern changes**: FLUSSSegmenter, ClaSPSegmenter
 - **Statistical changes**: InformationGainSegmenter, GreedyGaussianSegmenter
@@ -99,8 +99,10 @@ Identify when time series behavior fundamentally changes:
 ```python
 from aeon.segmentation import InformationGainSegmenter
 
-segmenter = InformationGainSegmenter(k=3)  # Up to 3 change points
-change_points = segmenter.fit_predict(stock_prices)
+# k_max caps the number of splits; this segmenter needs multivariate input
+# (shape (n_channels, n_timepoints)) and rejects univariate series.
+segmenter = InformationGainSegmenter(k_max=3)  # Up to 3 change points
+change_points = segmenter.fit_predict(multivariate_series)
 ```
 
 ### Activity Segmentation
@@ -118,8 +120,16 @@ Find season transitions in time series:
 
 ```python
 from aeon.segmentation import HMMSegmenter
+from scipy.stats import norm
+import numpy as np
 
-segmenter = HMMSegmenter(n_states=4)  # 4 seasons
+# HMMSegmenter needs the emission distributions and transition matrix up front.
+# 4 seasons = 4 hidden states; emission_funcs is a list of (callable, kwargs) pairs.
+centers = [0, 5, 10, 15]
+emission_funcs = [(norm.pdf, {"loc": m, "scale": 1.0}) for m in centers]
+transition_prob_mat = np.full((4, 4), 0.25)  # n_states x n_states
+
+segmenter = HMMSegmenter(emission_funcs, transition_prob_mat)
 segments = segmenter.fit_predict(temperature_data)
 ```
 

--- a/skills/aeon/references/similarity_search.md
+++ b/skills/aeon/references/similarity_search.md
@@ -36,7 +36,7 @@ Find similar time series across collections.
 ## Quick Start: Motif Discovery
 
 ```python
-from aeon.similarity_search import StompMotif
+from aeon.similarity_search.series import StompMotif
 import numpy as np
 
 # Create time series with repeated patterns
@@ -49,18 +49,19 @@ y = np.concatenate([
 ])
 
 # Find top-3 motifs
-motif_finder = StompMotif(window_size=50, k=3)
-motifs = motif_finder.fit_predict(y)
+motif_finder = StompMotif(length=50)
+motif_indices, motif_distances = motif_finder.fit_predict(y, k=3)
 
-# motifs contains indices of motif occurrences
-for i, (idx1, idx2) in enumerate(motifs):
+# each entry is a (1, 2) array of the two matched start positions
+for i, pair in enumerate(motif_indices):
+    idx1, idx2 = pair[0]
     print(f"Motif {i+1} at positions {idx1} and {idx2}")
 ```
 
 ## Quick Start: Subsequence Search
 
 ```python
-from aeon.similarity_search import MassSNN
+from aeon.similarity_search.series import MassSNN
 import numpy as np
 
 # Time series to search within
@@ -69,9 +70,10 @@ y = np.sin(np.linspace(0, 20, 500))
 # Query subsequence
 query = np.sin(np.linspace(0, 2, 50))
 
-# Find nearest subsequences
-searcher = MassSNN()
-distances = searcher.fit_transform(y, query)
+# Find nearest subsequences (series are shaped (n_channels, n_timepoints))
+searcher = MassSNN(length=len(query))
+searcher.fit(y.reshape(1, -1))
+distances = searcher.compute_distance_profile(query.reshape(1, -1))
 
 # Find best match
 best_match_idx = np.argmin(distances)
@@ -81,19 +83,19 @@ print(f"Best match at index {best_match_idx}")
 ## Quick Start: Approximate NN on Collections
 
 ```python
-from aeon.similarity_search import RandomProjectionIndexANN
+from aeon.similarity_search.collection import RandomProjectionIndexANN
 from aeon.datasets import load_classification
 
 # Load time series collection
 X_train, _ = load_classification("GunPoint", split="train")
 
 # Build index
-ann = RandomProjectionIndexANN(n_projections=8, n_bits=4)
+ann = RandomProjectionIndexANN(n_hash_funcs=8)
 ann.fit(X_train)
 
 # Find approximate nearest neighbors
 query = X_train[0]
-neighbors, distances = ann.kneighbors(query, k=5)
+neighbors, distances = ann.predict(query, k=5)
 ```
 
 ## Matrix Profile
@@ -106,18 +108,14 @@ The matrix profile is a fundamental data structure for many similarity search ta
 - **Discord**: Subsequence with maximum minimum distance (anomaly)
 
 ```python
-from aeon.similarity_search import StompMotif
+from aeon.similarity_search.series import StompMotif
 
-# Compute matrix profile and find motifs/discords
-mp = StompMotif(window_size=50)
-mp.fit(y)
+# StompMotif finds the top-k motif pairs; it has no matrix_profile_ attribute
+mp = StompMotif(length=50)
+motif_indices, motif_distances = mp.fit_predict(y, k=3)
 
-# Access matrix profile
-profile = mp.matrix_profile_
-profile_indices = mp.matrix_profile_index_
-
-# Find discords (anomalies)
-discord_idx = np.argmax(profile)
+# motif_indices[i][0] holds the two matched start positions of motif i
+first_motif = motif_indices[0][0]
 ```
 
 ## Algorithm Selection
@@ -135,8 +133,9 @@ Find where a pattern occurs in a long series:
 
 ```python
 # Find heartbeat pattern in ECG data
-searcher = MassSNN()
-distances = searcher.fit_transform(ecg_data, heartbeat_pattern)
+searcher = MassSNN(length=len(heartbeat_pattern))
+searcher.fit(ecg_data.reshape(1, -1))
+distances = searcher.compute_distance_profile(heartbeat_pattern.reshape(1, -1))
 occurrences = np.where(distances < threshold)[0]
 ```
 
@@ -145,8 +144,8 @@ Identify recurring patterns:
 
 ```python
 # Find repeated behavioral patterns
-motif_finder = StompMotif(window_size=100, k=5)
-motifs = motif_finder.fit_predict(activity_data)
+motif_finder = StompMotif(length=100)
+motifs = motif_finder.fit_predict(activity_data, k=5)
 ```
 
 ### Time Series Retrieval
@@ -158,7 +157,7 @@ ann = RandomProjectionIndexANN()
 ann.fit(time_series_database)
 
 # Query for similar series
-neighbors = ann.kneighbors(query_series, k=10)
+neighbors, distances = ann.predict(query_series, k=10)
 ```
 
 ## Best Practices

--- a/skills/aeon/references/transformations.md
+++ b/skills/aeon/references/transformations.md
@@ -14,12 +14,10 @@ Aeon distinguishes between:
 
 Fast, scalable feature generation using random kernels:
 
-- `RocketTransformer` - Random convolutional kernels
-- `MiniRocketTransformer` - Simplified ROCKET for speed
-- `MultiRocketTransformer` - Enhanced ROCKET variant
+- `Rocket` - Random convolutional kernels
+- `MiniRocket` - Simplified ROCKET for speed
+- `MultiRocket` - Enhanced ROCKET variant
 - `HydraTransformer` - Multi-resolution dilated convolutions
-- `MultiRocketHydraTransformer` - Combines ROCKET and Hydra
-- `ROCKETGPU` - GPU-accelerated variant
 
 **Use when**: Need fast, scalable features for any ML algorithm, strong baseline performance.
 
@@ -85,12 +83,10 @@ Data preparation and normalization:
 
 Advanced analysis methods:
 
-- `MatrixProfile` - Computes distance profiles for pattern discovery
+- `MatrixProfile` - Computes distance profiles for pattern discovery (deprecated since 1.4.0, removed in 1.5.0; use the series `MatrixProfileTransformer` with `SeriesToCollectionBroadcaster`)
 - `DWTTransformer` - Discrete Wavelet Transform
 - `AutocorrelationFunctionTransformer` - ACF computation
-- `Dobin` - Distance-based Outlier BasIs using Neighbors
-- `SignatureTransformer` - Path signature methods
-- `PLATransformer` - Piecewise Linear Approximation
+- `SignatureTransformer` - Path signature methods (import from `aeon.transformations.collection.signature_based`)
 
 ### Class Imbalance Handling
 
@@ -120,7 +116,7 @@ Transform individual time series (e.g., for preprocessing in forecasting).
 - `MovingAverage` - Simple or weighted moving average
 - `SavitzkyGolayFilter` - Polynomial smoothing
 - `GaussianFilter` - Gaussian kernel smoothing
-- `BKFilter` - Baxter-King bandpass filter
+- `BKFilter` - Baxter-King bandpass filter (import from `aeon.transformations.series`, not the `.smoothing` submodule)
 - `DiscreteFourierApproximation` - Fourier-based filtering
 
 **Use when**: Need noise reduction, trend extraction, or frequency filtering.
@@ -128,7 +124,8 @@ Transform individual time series (e.g., for preprocessing in forecasting).
 ### Dimensionality Reduction
 
 - `PCASeriesTransformer` - Principal component analysis
-- `PlASeriesTransformer` - Piecewise Linear Approximation
+- `PLASeriesTransformer` - Piecewise Linear Approximation
+- `Dobin` - Distance-based Outlier BasIs using Neighbors (dimension reduction for outlier detection)
 
 ### Transformations
 
@@ -143,8 +140,8 @@ Transform individual time series (e.g., for preprocessing in forecasting).
 ## Quick Start: Feature Extraction
 
 ```python
-from aeon.transformations.collection.convolution_based import RocketTransformer
-from aeon.classification.sklearn import RotationForest
+from aeon.transformations.collection.convolution_based import Rocket
+from aeon.classification.sklearn import RotationForestClassifier
 from aeon.datasets import load_classification
 
 # Load data
@@ -152,12 +149,12 @@ X_train, y_train = load_classification("GunPoint", split="train")
 X_test, y_test = load_classification("GunPoint", split="test")
 
 # Extract ROCKET features
-rocket = RocketTransformer()
+rocket = Rocket()
 X_train_features = rocket.fit_transform(X_train)
 X_test_features = rocket.transform(X_test)
 
 # Use with any sklearn classifier
-clf = RotationForest()
+clf = RotationForestClassifier()
 clf.fit(X_train_features, y_train)
 accuracy = clf.score(X_test_features, y_test)
 ```
@@ -165,11 +162,8 @@ accuracy = clf.score(X_test_features, y_test)
 ## Quick Start: Preprocessing Pipeline
 
 ```python
-from aeon.transformations.collection import (
-    MinMaxScaler,
-    SimpleImputer,
-    CollectionTransformerPipeline
-)
+from aeon.transformations.collection import MinMaxScaler, SimpleImputer
+from aeon.transformations.collection.compose import CollectionTransformerPipeline
 
 # Build preprocessing pipeline
 pipeline = CollectionTransformerPipeline([
@@ -183,7 +177,7 @@ X_transformed = pipeline.fit_transform(X_train)
 ## Quick Start: Series Smoothing
 
 ```python
-from aeon.transformations.series import MovingAverage
+from aeon.transformations.series.smoothing import MovingAverage
 
 # Smooth individual time series
 smoother = MovingAverage(window_size=5)
@@ -193,7 +187,7 @@ y_smoothed = smoother.fit_transform(y)
 ## Algorithm Selection
 
 ### For Feature Extraction:
-- **Speed + Performance**: MiniRocketTransformer
+- **Speed + Performance**: MiniRocket
 - **Interpretability**: Catch22, TSFresh
 - **Dimensionality reduction**: PAA, SAX, PCA
 - **Discriminative patterns**: Shapelet transforms
@@ -224,7 +218,7 @@ y_smoothed = smoother.fit_transform(y)
    pipeline = CollectionTransformerPipeline([
        ('imputer', SimpleImputer()),
        ('scaler', Normalizer()),
-       ('features', RocketTransformer())
+       ('features', Rocket())
    ])
    ```
 
@@ -238,7 +232,6 @@ y_smoothed = smoother.fit_transform(y)
 4. **Memory considerations**: Some transformers memory-intensive on large datasets
    - Use MiniRocket instead of ROCKET for speed
    - Consider downsampling for very long series
-   - Use ROCKETGPU for GPU acceleration
 
 5. **Domain knowledge**: Choose transformations matching domain:
    - Periodic data: Fourier-based methods


### PR DESCRIPTION
Several examples called aeon APIs that 1.4.0 removed, renamed, or moved, or that never existed, so they raise on copy-paste.

- forecasting: drop the non-existent `ForecastingHorizon`/`performance_metrics` imports; `NaiveForecaster` uses `"seasonal_last"` (not `"seasonal"`) and `seasonal_period`.
- transformations: `RotationForestClassifier` (not `RotationForest`); `MovingAverage` and the smoothers live under `.series.smoothing`; `CollectionTransformerPipeline` under `.compose`.
- segmentation: `HMMSegmenter` takes `emission_funcs`/`transition_prob_mat`; `InformationGainSegmenter` uses `k_max`.
- datasets/benchmarking: `get_dataset_meta_data` returns a DataFrame and takes a list; `nemenyi_test`/`wilcoxon_test` live in `.stats`; `save_to_ts_file`, `stratified_resample_data`, `clustering_accuracy_score`.
- classification/regression: `ClassifierEnsemble` (not `WeightedEnsembleClassifier`); `LITETimeRegressor` (not `LITERegressor`); ETS params `error_type`/`trend_type`/`seasonality_type`.

I ran every changed snippet against aeon 1.4.0 with scikit-learn pinned below 1.8.
