### PR TITLE
neurokit2: fix call signatures, tuple returns, and wrong method/column names (0.2.13)

### DIFF
--- a/skills/neurokit2/SKILL.md
+++ b/skills/neurokit2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neurokit2
-description: Comprehensive biosignal processing toolkit for analyzing physiological data including ECG, EEG, EDA, RSP, PPG, EMG, and EOG signals. Use this skill when processing cardiovascular signals, brain activity, electrodermal responses, respiratory patterns, muscle activity, or eye movements. Applicable for heart rate variability analysis, event-related potentials, complexity measures, autonomic nervous system assessment, psychophysiology research, and multi-modal physiological signal integration.
+description: 'Comprehensive biosignal processing toolkit for analyzing physiological data including ECG, EEG, EDA, RSP, PPG, EMG, and EOG signals. Use this skill when processing cardiovascular signals, brain activity, electrodermal responses, respiratory patterns, muscle activity, or eye movements. Applicable for heart rate variability analysis, event-related potentials, complexity measures, autonomic nervous system assessment, psychophysiology research, and multi-modal physiological signal integration.'
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.
@@ -69,7 +69,7 @@ hrv_indices = nk.hrv(peaks, sampling_rate=1000)
 hrv_time = nk.hrv_time(peaks)
 hrv_freq = nk.hrv_frequency(peaks, sampling_rate=1000)
 hrv_nonlinear = nk.hrv_nonlinear(peaks, sampling_rate=1000)
-hrv_rsa = nk.hrv_rsa(peaks, rsp_signal, sampling_rate=1000)
+hrv_rsa = nk.hrv_rsa(ecg_signals, rsp_signals, sampling_rate=1000)
 ```
 
 ### 3. Brain Signal Analysis (EEG)
@@ -86,12 +86,13 @@ Analyze electroencephalography signals for frequency power, complexity, and micr
 **Key functions:**
 ```python
 # Power analysis across frequency bands
-power = nk.eeg_power(eeg_data, sampling_rate=250, channels=['Fz', 'Cz', 'Pz'])
+power = nk.eeg_power(eeg_data, sampling_rate=250,
+                     frequency_band=['Delta', 'Theta', 'Alpha', 'Beta', 'Gamma'])
 
 # Microstate analysis
-microstates = nk.microstates_segment(eeg_data, n_microstates=4, method='kmod')
-static = nk.microstates_static(microstates)
-dynamic = nk.microstates_dynamic(microstates)
+microstates = nk.microstates_segment(eeg_data, n_microstates=4, sampling_rate=250, method='kmod')
+static = nk.microstates_static(microstates["Sequence"])
+dynamic = nk.microstates_dynamic(microstates["Sequence"])
 ```
 
 ### 4. Electrodermal Activity (EDA)
@@ -113,7 +114,7 @@ signals, info = nk.eda_process(eda_signal, sampling_rate=100)
 analysis = nk.eda_analyze(signals, sampling_rate=100)
 
 # Sympathetic nervous system activity
-sympathetic = nk.eda_sympathetic(signals, sampling_rate=100)
+sympathetic = nk.eda_sympathetic(signals["EDA_Clean"], sampling_rate=100)
 ```
 
 ### 5. Respiratory Signal Processing (RSP)
@@ -135,7 +136,7 @@ signals, info = nk.rsp_process(rsp_signal, sampling_rate=100)
 rrv = nk.rsp_rrv(signals, sampling_rate=100)
 
 # Respiratory volume per time
-rvt = nk.rsp_rvt(signals, sampling_rate=100)
+rvt = nk.rsp_rvt(signals["RSP_Clean"], sampling_rate=100)
 ```
 
 ### 6. Electromyography (EMG)
@@ -148,7 +149,7 @@ Process muscle activity signals for activation detection and amplitude analysis.
 signals, info = nk.emg_process(emg_signal, sampling_rate=1000)
 
 # Muscle activation detection
-activation = nk.emg_activation(signals, sampling_rate=1000, method='threshold')
+activation, info = nk.emg_activation(signals["EMG_Amplitude"], sampling_rate=1000, method='threshold')
 ```
 
 ### 7. Electrooculography (EOG)
@@ -161,8 +162,10 @@ Analyze eye movement and blink patterns. See `references/eog.md` for workflows.
 signals, info = nk.eog_process(eog_signal, sampling_rate=500)
 
 # Extract blink features
-features = nk.eog_features(signals, sampling_rate=500)
+features = nk.eog_features(signals["EOG_Clean"], info["EOG_Blinks"], sampling_rate=500)
 ```
+
+> **Note:** The default EOG blink detection relies on MNE-Python, so install it (`uv pip install mne` or `neurokit2[full]`). To avoid the MNE dependency, pass `method="brainstorm"` to `nk.eog_process()`.
 
 ### 8. General Signal Processing
 
@@ -202,12 +205,12 @@ Compute nonlinear dynamics, fractal dimensions, and information-theoretic measur
 **Key functions:**
 ```python
 # Multiple complexity metrics at once
-complexity_indices = nk.complexity(signal, sampling_rate=1000)
+complexity_indices, info = nk.complexity(signal, sampling_rate=1000)
 
 # Specific measures
-apen = nk.entropy_approximate(signal)
-dfa = nk.fractal_dfa(signal)
-lyap = nk.complexity_lyapunov(signal, sampling_rate=1000)
+apen, _ = nk.entropy_approximate(signal)
+dfa, _ = nk.fractal_dfa(signal)
+lyap, _ = nk.complexity_lyapunov(signal, sampling_rate=1000)
 ```
 
 ### 10. Event-Related Analysis

--- a/skills/neurokit2/references/bio_module.md
+++ b/skills/neurokit2/references/bio_module.md
@@ -47,8 +47,8 @@ rsp_rate = bio_signals['RSP_Rate']
 eda_phasic = bio_signals['EDA_Phasic']
 
 # Access detected peaks
-ecg_peaks = bio_info['ECG']['ECG_R_Peaks']
-rsp_peaks = bio_info['RSP']['RSP_Peaks']
+ecg_peaks = bio_info['ECG_R_Peaks']
+rsp_peaks = bio_info['RSP_Peaks']
 ```
 
 **Internal workflow:**
@@ -111,7 +111,7 @@ heart_rate_mean = results['ECG_Rate_Mean']
 hrv_rmssd = results['HRV_RMSSD']
 breathing_rate = results['RSP_Rate_Mean']
 scr_count = results['SCR_Peaks_N']
-rsa_value = results['RSA']  # If both ECG and RSP present
+rsa_value = results['RSA_P2T_Mean']  # If both ECG and RSP present (no plain 'RSA' column; use a specific RSA_* key, e.g. RSA_P2T_Mean or RSA_PorgesBohrer)
 ```
 
 ## Cross-Signal Features
@@ -126,7 +126,7 @@ Automatically computed when both ECG and respiratory signals are present.
 bio_signals, bio_info = nk.bio_process(ecg=ecg, rsp=rsp, sampling_rate=1000)
 results = nk.bio_analyze(bio_signals, sampling_rate=1000)
 
-rsa = results['RSA']  # Automatically included
+rsa = results['RSA_P2T_Mean']  # Automatically included (bio_analyze emits RSA_* columns such as RSA_P2T_Mean and RSA_PorgesBohrer, not a plain 'RSA')
 ```
 
 **Computation:**
@@ -147,7 +147,7 @@ If respiratory signal unavailable, NeuroKit2 can estimate from ECG:
 ecg_signals, ecg_info = nk.ecg_process(ecg, sampling_rate=1000)
 
 # Extract EDR
-edr = nk.ecg_rsp(ecg_signals['ECG_Clean'], sampling_rate=1000)
+edr = nk.ecg_rsp(ecg_signals['ECG_Rate'], sampling_rate=1000)
 ```
 
 **Use case:**
@@ -226,7 +226,7 @@ print("Heart Rate (mean):", results['ECG_Rate_Mean'])
 print("HRV (RMSSD):", results['HRV_RMSSD'])
 print("Breathing Rate:", results['RSP_Rate_Mean'])
 print("SCRs (count):", results['SCR_Peaks_N'])
-print("RSA:", results['RSA'])
+print("RSA:", results['RSA_P2T_Mean'])
 ```
 
 ### Event-Related Multi-Modal Analysis

--- a/skills/neurokit2/references/complexity.md
+++ b/skills/neurokit2/references/complexity.md
@@ -11,11 +11,11 @@ Complexity measures quantify the irregularity, unpredictability, and multiscale 
 Compute multiple complexity metrics simultaneously for exploratory analysis.
 
 ```python
-complexity_indices = nk.complexity(signal, sampling_rate=1000, show=False)
+complexity_indices, info = nk.complexity(signal, sampling_rate=1000, show=False)
 ```
 
 **Returns:**
-- DataFrame with numerous complexity measures across categories:
+- A tuple `(df, info)` where `df` is a DataFrame with numerous complexity measures across categories:
   - Entropy indices
   - Fractal dimensions
   - Nonlinear dynamics measures
@@ -35,13 +35,13 @@ Before computing complexity measures, optimal embedding parameters should be det
 Determine optimal time delay (τ) for phase space reconstruction.
 
 ```python
-optimal_tau = nk.complexity_delay(signal, delay_max=100, method='fraser1986', show=False)
+optimal_tau, info = nk.complexity_delay(signal, delay_max=100, method='fraser1986', show=False)
 ```
 
 **Methods:**
-- `'fraser1986'`: Mutual information first minimum
-- `'theiler1990'`: Autocorrelation first zero crossing
-- `'casdagli1991'`: Cao's method
+- `'fraser1986'`: First local minimum of the mutual information
+- `'theiler1990'`: Lag where the autocorrelation first drops to 1/e
+- `'casdagli1991'`: First zero-crossing of the autocorrelation
 
 **Use for:** Embedding delay in entropy, attractor reconstruction
 
@@ -50,8 +50,8 @@ optimal_tau = nk.complexity_delay(signal, delay_max=100, method='fraser1986', sh
 Determine optimal embedding dimension (m).
 
 ```python
-optimal_m = nk.complexity_dimension(signal, delay=None, dimension_max=20,
-                                    method='afn', show=False)
+optimal_m, info = nk.complexity_dimension(signal, delay=None, dimension_max=20,
+                                          method='afn', show=False)
 ```
 
 **Methods:**
@@ -66,7 +66,7 @@ optimal_m = nk.complexity_dimension(signal, delay=None, dimension_max=20,
 Determine optimal tolerance (r) for entropy measures.
 
 ```python
-optimal_r = nk.complexity_tolerance(signal, method='sd', show=False)
+optimal_r, info = nk.complexity_tolerance(signal, method='sd', show=False)
 ```
 
 **Methods:**
@@ -81,7 +81,7 @@ optimal_r = nk.complexity_tolerance(signal, method='sd', show=False)
 Determine optimal k parameter for Higuchi fractal dimension.
 
 ```python
-optimal_k = nk.complexity_k(signal, k_max=20, show=False)
+optimal_k, info = nk.complexity_k(signal, k_max=20, show=False)
 ```
 
 **Use for:** Higuchi fractal dimension calculation
@@ -95,7 +95,7 @@ Entropy quantifies randomness, unpredictability, and information content.
 Shannon entropy - classical information-theoretic measure.
 
 ```python
-shannon_entropy = nk.entropy_shannon(signal)
+shannon_entropy, info = nk.entropy_shannon(signal)
 ```
 
 **Interpretation:**
@@ -113,7 +113,7 @@ shannon_entropy = nk.entropy_shannon(signal)
 Approximate Entropy (ApEn) - regularity of patterns.
 
 ```python
-apen = nk.entropy_approximate(signal, delay=1, dimension=2, tolerance='sd')
+apen, _ = nk.entropy_approximate(signal, delay=1, dimension=2, tolerance='sd')
 ```
 
 **Parameters:**
@@ -135,7 +135,7 @@ apen = nk.entropy_approximate(signal, delay=1, dimension=2, tolerance='sd')
 Sample Entropy (SampEn) - improved ApEn.
 
 ```python
-sampen = nk.entropy_sample(signal, delay=1, dimension=2, tolerance='sd')
+sampen, info = nk.entropy_sample(signal, delay=1, dimension=2, tolerance='sd')
 ```
 
 **Advantages over ApEn:**
@@ -156,8 +156,8 @@ sampen = nk.entropy_sample(signal, delay=1, dimension=2, tolerance='sd')
 Multiscale Entropy (MSE) - complexity across temporal scales.
 
 ```python
-mse = nk.entropy_multiscale(signal, scale=20, dimension=2, tolerance='sd',
-                            method='MSEn', show=False)
+mse, info = nk.entropy_multiscale(signal, scale=20, dimension=2, tolerance='sd',
+                                  method='MSEn', show=False)
 ```
 
 **Methods:**
@@ -181,7 +181,7 @@ mse = nk.entropy_multiscale(signal, scale=20, dimension=2, tolerance='sd',
 Fuzzy Entropy - uses fuzzy membership functions.
 
 ```python
-fuzzen = nk.entropy_fuzzy(signal, delay=1, dimension=2, tolerance='sd', r=0.2)
+fuzzen, info = nk.entropy_fuzzy(signal, delay=1, dimension=2, tolerance='sd', r=0.2)
 ```
 
 **Advantages:**
@@ -194,7 +194,7 @@ fuzzen = nk.entropy_fuzzy(signal, delay=1, dimension=2, tolerance='sd', r=0.2)
 Permutation Entropy - based on ordinal patterns.
 
 ```python
-perment = nk.entropy_permutation(signal, delay=1, dimension=3)
+perment, info = nk.entropy_permutation(signal, delay=1, dimension=3)
 ```
 
 **Method:**
@@ -216,7 +216,7 @@ perment = nk.entropy_permutation(signal, delay=1, dimension=3)
 Spectral Entropy - based on power spectrum.
 
 ```python
-spec_ent = nk.entropy_spectral(signal, sampling_rate=1000, bands=None)
+spec_ent, info = nk.entropy_spectral(signal)
 ```
 
 **Method:**
@@ -236,7 +236,7 @@ spec_ent = nk.entropy_spectral(signal, sampling_rate=1000, bands=None)
 Singular Value Decomposition Entropy.
 
 ```python
-svd_ent = nk.entropy_svd(signal, delay=1, dimension=2)
+svd_ent, info = nk.entropy_svd(signal, delay=1, dimension=2)
 ```
 
 **Method:**
@@ -252,7 +252,7 @@ svd_ent = nk.entropy_svd(signal, delay=1, dimension=2)
 Differential Entropy - continuous analog of Shannon entropy.
 
 ```python
-diff_ent = nk.entropy_differential(signal)
+diff_ent, info = nk.entropy_differential(signal)
 ```
 
 **Use for:** Continuous probability distributions
@@ -261,14 +261,14 @@ diff_ent = nk.entropy_differential(signal)
 
 **Tsallis Entropy:**
 ```python
-tsallis = nk.entropy_tsallis(signal, q=2)
+tsallis, info = nk.entropy_tsallis(signal, q=2)
 ```
 - Generalized entropy with parameter q
 - q=1 reduces to Shannon entropy
 
 **Rényi Entropy:**
 ```python
-renyi = nk.entropy_renyi(signal, alpha=2)
+renyi, info = nk.entropy_renyi(signal, alpha=2)
 ```
 - Generalized entropy with parameter α
 
@@ -281,7 +281,7 @@ renyi = nk.entropy_renyi(signal, alpha=2)
 - `entropy_symbolicdynamic()`: Symbolic dynamics entropy
 - `entropy_range()`: Range entropy
 - `entropy_phase()`: Phase entropy
-- `entropy_quadratic()`, `entropy_cumulative_residual()`, `entropy_rate()`: Specialized variants
+- `entropy_quadratic()`, `entropy_cumulativeresidual()`, `entropy_rate()`: Specialized variants
 
 ## Fractal Dimension Measures
 
@@ -292,7 +292,7 @@ Fractal dimensions characterize self-similarity and roughness.
 Katz Fractal Dimension - waveform complexity.
 
 ```python
-kfd = nk.fractal_katz(signal)
+kfd, info = nk.fractal_katz(signal)
 ```
 
 **Interpretation:**
@@ -309,7 +309,7 @@ kfd = nk.fractal_katz(signal)
 Higuchi Fractal Dimension - self-similarity.
 
 ```python
-hfd = nk.fractal_higuchi(signal, k_max=10)
+hfd, info = nk.fractal_higuchi(signal, k_max=10)
 ```
 
 **Method:**
@@ -330,7 +330,7 @@ hfd = nk.fractal_higuchi(signal, k_max=10)
 Petrosian Fractal Dimension - rapid estimation.
 
 ```python
-pfd = nk.fractal_petrosian(signal)
+pfd, info = nk.fractal_petrosian(signal)
 ```
 
 **Advantages:**
@@ -342,7 +342,7 @@ pfd = nk.fractal_petrosian(signal)
 Sevcik Fractal Dimension - normalized waveform complexity.
 
 ```python
-sfd = nk.fractal_sevcik(signal)
+sfd, info = nk.fractal_sevcik(signal)
 ```
 
 ### fractal_nld()
@@ -350,7 +350,7 @@ sfd = nk.fractal_sevcik(signal)
 Normalized Length Density - curve length-based measure.
 
 ```python
-nld = nk.fractal_nld(signal)
+nld, info = nk.fractal_nld(signal)
 ```
 
 ### fractal_psdslope()
@@ -358,7 +358,7 @@ nld = nk.fractal_nld(signal)
 Power Spectral Density Slope - frequency-domain fractal measure.
 
 ```python
-slope = nk.fractal_psdslope(signal, sampling_rate=1000)
+slope, info = nk.fractal_psdslope(signal)
 ```
 
 **Method:**
@@ -375,7 +375,7 @@ slope = nk.fractal_psdslope(signal, sampling_rate=1000)
 Hurst Exponent - long-range dependence.
 
 ```python
-hurst = nk.fractal_hurst(signal, show=False)
+hurst, info = nk.fractal_hurst(signal, show=False)
 ```
 
 **Interpretation:**
@@ -393,7 +393,7 @@ hurst = nk.fractal_hurst(signal, show=False)
 Correlation Dimension - attractor dimensionality.
 
 ```python
-corr_dim = nk.fractal_correlation(signal, delay=1, dimension=10, radius=64)
+corr_dim, info = nk.fractal_correlation(signal, delay=1, dimension=10, radius=64)
 ```
 
 **Method:**
@@ -409,7 +409,7 @@ corr_dim = nk.fractal_correlation(signal, delay=1, dimension=10, radius=64)
 Detrended Fluctuation Analysis - scaling exponent.
 
 ```python
-dfa_alpha = nk.fractal_dfa(signal, multifractal=False, q=2, show=False)
+dfa_alpha, _ = nk.fractal_dfa(signal, multifractal=False, q=2, show=False)
 ```
 
 **Interpretation:**
@@ -429,7 +429,7 @@ dfa_alpha = nk.fractal_dfa(signal, multifractal=False, q=2, show=False)
 Multifractal DFA - multiscale fractal properties.
 
 ```python
-mfdfa_results = nk.fractal_mfdfa(signal, q=None, show=False)
+mfdfa_results, info = nk.fractal_mfdfa(signal, show=False)
 ```
 
 **Method:**
@@ -451,7 +451,7 @@ mfdfa_results = nk.fractal_mfdfa(signal, q=None, show=False)
 Multifractal Nonlinearity - deviation from monofractal.
 
 ```python
-tmf = nk.fractal_tmf(signal)
+tmf, info = nk.fractal_tmf(signal)
 ```
 
 **Interpretation:**
@@ -463,7 +463,7 @@ tmf = nk.fractal_tmf(signal)
 Density Fractal Dimension.
 
 ```python
-density_fd = nk.fractal_density(signal)
+density_fd, info = nk.fractal_density(signal)
 ```
 
 ### fractal_linelength()
@@ -471,7 +471,7 @@ density_fd = nk.fractal_density(signal)
 Line Length - total variation measure.
 
 ```python
-linelength = nk.fractal_linelength(signal)
+linelength, info = nk.fractal_linelength(signal)
 ```
 
 **Use case:**
@@ -485,8 +485,7 @@ linelength = nk.fractal_linelength(signal)
 Largest Lyapunov Exponent - chaos and divergence.
 
 ```python
-lyap = nk.complexity_lyapunov(signal, delay=None, dimension=None,
-                              sampling_rate=1000, show=False)
+lyap, _ = nk.complexity_lyapunov(signal, delay=1, dimension=2, show=False)
 ```
 
 **Interpretation:**
@@ -504,7 +503,7 @@ lyap = nk.complexity_lyapunov(signal, delay=None, dimension=None,
 Lempel-Ziv Complexity - algorithmic complexity.
 
 ```python
-lz = nk.complexity_lempelziv(signal, symbolize='median')
+lz, info = nk.complexity_lempelziv(signal, symbolize='median')
 ```
 
 **Method:**
@@ -524,7 +523,7 @@ lz = nk.complexity_lempelziv(signal, symbolize='median')
 Recurrence Quantification Analysis - phase space recurrences.
 
 ```python
-rqa_indices = nk.complexity_rqa(signal, delay=1, dimension=3, tolerance='sd')
+rqa_indices, info = nk.complexity_rqa(signal, delay=1, dimension=3, tolerance='sd')
 ```
 
 **Metrics:**
@@ -550,7 +549,7 @@ rqa_indices = nk.complexity_rqa(signal, delay=1, dimension=3, tolerance='sd')
 Hjorth Parameters - time-domain complexity.
 
 ```python
-hjorth = nk.complexity_hjorth(signal)
+hjorth, info = nk.complexity_hjorth(signal)
 ```
 
 **Metrics:**
@@ -568,7 +567,7 @@ hjorth = nk.complexity_hjorth(signal)
 Decorrelation Time - memory duration.
 
 ```python
-decorr_time = nk.complexity_decorrelation(signal, show=False)
+decorr_time, info = nk.complexity_decorrelation(signal, show=False)
 ```
 
 **Interpretation:**
@@ -581,7 +580,7 @@ decorr_time = nk.complexity_decorrelation(signal, show=False)
 Relative Roughness - smoothness measure.
 
 ```python
-roughness = nk.complexity_relativeroughness(signal)
+roughness, info = nk.complexity_relativeroughness(signal)
 ```
 
 ## Information Theory
@@ -591,7 +590,7 @@ roughness = nk.complexity_relativeroughness(signal)
 Fisher Information - measure of order.
 
 ```python
-fisher = nk.fisher_information(signal, delay=1, dimension=2)
+fisher, info = nk.fisher_information(signal, delay=1, dimension=2)
 ```
 
 **Interpretation:**
@@ -607,7 +606,7 @@ fisher = nk.fisher_information(signal, delay=1, dimension=2)
 Fisher-Shannon Information Product.
 
 ```python
-fs = nk.fishershannon_information(signal)
+fs, info = nk.fishershannon_information(signal)
 ```
 
 **Method:**

--- a/skills/neurokit2/references/ecg_cardiac.md
+++ b/skills/neurokit2/references/ecg_cardiac.md
@@ -70,7 +70,9 @@ peaks_dict, info = nk.ecg_peaks(cleaned_ecg, sampling_rate=1000, method='neuroki
 - `'elgendi2010'`: Elgendi's two moving averages
 - `'engzeemod2012'`: Modified Engelse-Zeelenberg
 - `'kalidas2017'`: XQRS-based
-- `'martinez2004'`, `'rodrigues2021'`, `'koka2022'`, `'promac'`: Advanced methods
+- `'martinez2004'`, `'rodrigues2021'`, `'emrich2023'`, `'promac'`: Advanced methods
+
+> **Note:** `'koka2022'` has been renamed to `'emrich2023'` (passing `'koka2022'` still works but emits a deprecation warning). This visibility-graph method additionally requires the optional `ts2vg` package (`uv pip install ts2vg`).
 
 **Artifact correction:**
 Set `correct_artifacts=True` to apply Lipponen & Tarvainen (2019) correction:
@@ -242,7 +244,7 @@ corrected_ecg, is_inverted = nk.ecg_invert(ecg_signal, sampling_rate=1000)
 Extract ECG-derived respiration (EDR) as respiratory proxy signal.
 
 ```python
-edr_signal = nk.ecg_rsp(ecg_cleaned, sampling_rate=1000, method='vangent2019')
+edr_signal = nk.ecg_rsp(ecg_rate, sampling_rate=1000, method='vangent2019')
 ```
 
 **Methods:**
@@ -333,7 +335,7 @@ ecg_signals, ecg_info = nk.ecg_process(ecg, sampling_rate=1000)
 rsp_signals, rsp_info = nk.rsp_process(rsp, sampling_rate=1000)
 
 # Compute RSA
-rsa = nk.hrv_rsa(ecg_info['ECG_R_Peaks'], rsp_signals['RSP_Clean'], sampling_rate=1000)
+rsa = nk.hrv_rsa(ecg_signals, rsp_signals, sampling_rate=1000)
 ```
 
 ### Multi-modal Integration

--- a/skills/neurokit2/references/eda.md
+++ b/skills/neurokit2/references/eda.md
@@ -60,31 +60,36 @@ cleaned_eda = nk.eda_clean(eda_signal, sampling_rate=100, method='neurokit')
 Decompose EDA into tonic (slow baseline) and phasic (rapid responses) components.
 
 ```python
-tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='cvxeda')
+df = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='cvxeda')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 ```
 
 **Methods:**
 
-**1. cvxEDA (default, recommended):**
+**1. cvxEDA (recommended):**
 ```python
-tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='cvxeda')
+df = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='cvxeda')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 ```
 - Convex optimization approach (Greco et al., 2016)
 - Sparse phasic driver model
 - Most physiologically accurate
 - Computationally intensive but superior decomposition
+- Requires the optional `cvxopt` package (`uv pip install cvxopt`); without it this method raises ImportError. The default `'highpass'`, plus `'smoothmedian'` and `'sparseda'`, work without extra dependencies.
 
 **2. Median smoothing:**
 ```python
-tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='smoothmedian')
+df = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='smoothmedian')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 ```
 - Median filter with configurable window
 - Fast, simple
 - Less accurate than cvxEDA
 
-**3. High-pass filtering (Biopac's Acqknowledge):**
+**3. High-pass filtering (Biopac's Acqknowledge, default):**
 ```python
-tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='highpass')
+df = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='highpass')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 ```
 - High-pass filter (0.05 Hz) extracts phasic
 - Fast computation
@@ -92,7 +97,8 @@ tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='highpass')
 
 **4. SparsEDA:**
 ```python
-tonic, phasic = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='sparseda')
+df = nk.eda_phasic(eda_cleaned, sampling_rate=100, method='sparseda')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 ```
 - Sparse deconvolution approach
 - Alternative optimization method
@@ -125,8 +131,6 @@ peaks, info = nk.eda_peaks(eda_phasic, sampling_rate=100, method='neurokit',
 - `amplitude_min`: Minimum SCR amplitude (default: 0.1 µS)
   - Too low: false positives from noise
   - Too high: miss small but valid responses
-- `rise_time_max`: Maximum rise time (default: 2 seconds)
-- `rise_time_min`: Minimum rise time (default: 0.01 seconds)
 
 **Returns:**
 - Dictionary with:
@@ -234,7 +238,7 @@ results = nk.eda_intervalrelated(signals, sampling_rate=100)
 Derive sympathetic nervous system activity from frequency band (0.045-0.25 Hz).
 
 ```python
-sympathetic = nk.eda_sympathetic(signals, sampling_rate=100, method='posada',
+sympathetic = nk.eda_sympathetic(signals["EDA_Clean"], sampling_rate=100, method='posada',
                                   show=False)
 ```
 
@@ -269,7 +273,7 @@ sympathetic = nk.eda_sympathetic(signals, sampling_rate=100, method='posada',
 Compute autocorrelation to assess temporal structure of EDA signal.
 
 ```python
-autocorr = nk.eda_autocor(eda_phasic, sampling_rate=100, lag=4)
+autocorr = nk.eda_autocor(eda_cleaned, sampling_rate=100, lag=4)
 ```
 
 **Parameters:**
@@ -290,7 +294,7 @@ autocorr = nk.eda_autocor(eda_phasic, sampling_rate=100, lag=4)
 Detect abrupt shifts in mean and variance of EDA signal.
 
 ```python
-changepoints = nk.eda_changepoints(eda_phasic, penalty=10000, show=False)
+changepoints = nk.eda_changepoints(eda_cleaned, penalty=10000, show=False)
 ```
 
 **Method:**
@@ -410,8 +414,9 @@ synthetic_eda = nk.eda_simulate(duration=10, sampling_rate=100, scr_number=3,
 # 1. Clean signal
 cleaned = nk.eda_clean(eda_raw, sampling_rate=100, method='neurokit')
 
-# 2. Decompose tonic/phasic
-tonic, phasic = nk.eda_phasic(cleaned, sampling_rate=100, method='cvxeda')
+# 2. Decompose tonic/phasic (use method='cvxeda' for best accuracy if cvxopt is installed)
+df = nk.eda_phasic(cleaned, sampling_rate=100, method='highpass')
+tonic, phasic = df['EDA_Tonic'], df['EDA_Phasic']
 
 # 3. Detect SCRs
 signals, info = nk.eda_peaks(phasic, sampling_rate=100, amplitude_min=0.05)

--- a/skills/neurokit2/references/eeg.md
+++ b/skills/neurokit2/references/eeg.md
@@ -11,12 +11,12 @@ Analyze electroencephalography (EEG) signals for frequency band power, channel q
 Compute power across standard frequency bands for specified channels.
 
 ```python
-power = nk.eeg_power(eeg_data, sampling_rate=250, channels=['Fz', 'Cz', 'Pz'],
-                     frequency_bands={'Delta': (0.5, 4),
-                                     'Theta': (4, 8),
-                                     'Alpha': (8, 13),
-                                     'Beta': (13, 30),
-                                     'Gamma': (30, 45)})
+power = nk.eeg_power(eeg_data, sampling_rate=250,
+                     frequency_band=[(0.5, 4),
+                                     (4, 8),
+                                     (8, 13),
+                                     (13, 30),
+                                     (30, 45)])
 ```
 
 **Standard frequency bands:**
@@ -27,8 +27,8 @@ power = nk.eeg_power(eeg_data, sampling_rate=250, channels=['Fz', 'Cz', 'Pz'],
 - **Gamma (30-45 Hz)**: Cognitive processing, binding
 
 **Returns:**
-- DataFrame with power values for each channel × frequency band combination
-- Columns: `Channel_Band` (e.g., 'Fz_Alpha', 'Cz_Beta')
+- DataFrame with one row per channel and one column per band, plus a `Channel` column
+- Columns: `Channel`, `Gamma`, `Beta`, `Alpha`, `Theta`, `Delta` (band columns follow the requested `frequency_band`)
 
 **Use cases:**
 - Resting state analysis
@@ -41,7 +41,7 @@ power = nk.eeg_power(eeg_data, sampling_rate=250, channels=['Fz', 'Cz', 'Pz'],
 Identify problematic channels using statistical outlier detection.
 
 ```python
-bad_channels = nk.eeg_badchannels(eeg_data, sampling_rate=250, bad_threshold=2)
+bad_channels = nk.eeg_badchannels(eeg_data, sampling_rate=250, bad_threshold=0.5)
 ```
 
 **Detection methods:**
@@ -51,7 +51,8 @@ bad_channels = nk.eeg_badchannels(eeg_data, sampling_rate=250, bad_threshold=2)
 - Channels with excessive noise
 
 **Parameters:**
-- `bad_threshold`: Z-score threshold for outlier detection (default: 2)
+- `bad_threshold`: Correlation-based threshold for flagging a channel as bad (default: 0.5)
+- `distance_threshold`: Threshold on the cumulative density of correlations (default: 0.99)
 
 **Returns:**
 - List of channel names identified as problematic
@@ -107,7 +108,7 @@ gfp = nk.eeg_gfp(eeg_data)
 Measure topographic dissimilarity between electric field configurations.
 
 ```python
-dissimilarity = nk.eeg_diss(eeg_data1, eeg_data2, method='gfp')
+dissimilarity = nk.eeg_diss(eeg_data)  # DISS per time point for one EEG array (optionally pass a precomputed gfp=)
 ```
 
 **Methods:**
@@ -182,7 +183,7 @@ Identify and extract microstates using clustering algorithms.
 
 ```python
 microstates = nk.microstates_segment(eeg_data, n_microstates=4, sampling_rate=250,
-                                      method='kmod', normalize=True)
+                                      method='kmod', standardize_eeg=True)
 ```
 
 **Methods:**
@@ -197,15 +198,15 @@ microstates = nk.microstates_segment(eeg_data, n_microstates=4, sampling_rate=25
 
 **Parameters:**
 - `n_microstates`: Number of microstate classes (typically 4-7)
-- `normalize`: Normalize topographies (recommended: True)
-- `n_inits`: Number of random initializations (increase for stability)
+- `standardize_eeg`: Standardize the EEG before segmentation (recommended: True)
+- `n_runs`: Number of random initializations (increase for stability)
 
 **Returns:**
-- Dictionary with:
-  - `'maps'`: Microstate template topographies
-  - `'labels'`: Microstate label at each time point
-  - `'gfp'`: Global field power
-  - `'gev'`: Global explained variance
+- Dictionary with (among others):
+  - `'Microstates'`: Microstate template topographies (maps)
+  - `'Sequence'`: Microstate label at each time point
+  - `'GFP'`: Global field power
+  - `'GEV'`: Global explained variance (total; `'GEV_per_microstate'` gives the per-class breakdown)
 
 ### microstates_findnumber()
 
@@ -231,7 +232,7 @@ optimal_k = nk.microstates_findnumber(eeg_data, show=True)
 Reorder microstates based on anterior-posterior and left-right channel values.
 
 ```python
-classified = nk.microstates_classify(microstates)
+classified = nk.microstates_classify(microstates["Sequence"], microstates["Microstates"])
 ```
 
 **Purpose:**
@@ -284,7 +285,7 @@ peak_indices = nk.microstates_peaks(eeg_data, sampling_rate=250)
 Compute temporal properties of individual microstates.
 
 ```python
-static_metrics = nk.microstates_static(microstates)
+static_metrics = nk.microstates_static(microstates["Sequence"])
 ```
 
 **Metrics:**
@@ -311,7 +312,7 @@ static_metrics = nk.microstates_static(microstates)
 Analyze transition patterns between microstates.
 
 ```python
-dynamic_metrics = nk.microstates_dynamic(microstates)
+dynamic_metrics = nk.microstates_dynamic(microstates["Sequence"])
 ```
 
 **Metrics:**
@@ -353,7 +354,7 @@ nk.microstates_plot(microstates, eeg_data)
 Access sample datasets from MNE-Python.
 
 ```python
-raw = nk.mne_data(dataset='sample', directory=None)
+raw = nk.mne_data(what='raw', path=None)
 ```
 
 **Available datasets:**
@@ -449,7 +450,7 @@ bad = nk.eeg_badchannels(cleaned, sampling_rate=250)
 rereferenced = nk.eeg_rereference(cleaned, reference='average')
 
 # 4. Compute power
-power = nk.eeg_power(rereferenced, sampling_rate=250, channels=channel_list)
+power = nk.eeg_power(rereferenced, sampling_rate=250)
 ```
 
 **Microstate workflow:**
@@ -464,12 +465,12 @@ optimal_k = nk.microstates_findnumber(cleaned, show=True)
 microstates = nk.microstates_segment(cleaned, n_microstates=optimal_k,
                                      sampling_rate=250, method='kmod')
 
-# 4. Classify to standard labels
-microstates = nk.microstates_classify(microstates)
+# 4. Classify to standard labels (returns the reordered maps; keep the segment dict)
+classified = nk.microstates_classify(microstates["Sequence"], microstates["Microstates"])
 
 # 5. Compute temporal metrics
-static = nk.microstates_static(microstates)
-dynamic = nk.microstates_dynamic(microstates)
+static = nk.microstates_static(microstates["Sequence"])
+dynamic = nk.microstates_dynamic(microstates["Sequence"])
 
 # 6. Visualize
 nk.microstates_plot(microstates, cleaned)

--- a/skills/neurokit2/references/emg.md
+++ b/skills/neurokit2/references/emg.md
@@ -92,17 +92,17 @@ Detect periods of muscle activation (onsets and offsets).
 
 ```python
 activity, info = nk.emg_activation(emg_amplitude, sampling_rate=1000, method='threshold',
-                                   threshold='auto', duration_min=0.05)
+                                   threshold='default', duration_min=0.05)
 ```
 
 **Methods:**
 
 **1. Threshold-based (default):**
 ```python
-activity = nk.emg_activation(amplitude, method='threshold', threshold='auto')
+activity = nk.emg_activation(amplitude, method='threshold', threshold='default')
 ```
 - Compares amplitude to threshold
-- `threshold='auto'`: Automatic based on signal statistics (e.g., mean + 1 SD)
+- `threshold='default'`: Automatic based on signal statistics (e.g., mean + 1 SD)
 - `threshold=0.1`: Manual absolute threshold
 - Simple, fast, widely used
 
@@ -114,21 +114,20 @@ activity = nk.emg_activation(amplitude, method='mixture', n_clusters=2)
 - Adaptive to signal characteristics
 - More robust to varying baseline
 
-**3. Changepoint detection:**
+**3. Changepoint detection (PELT):**
 ```python
-activity = nk.emg_activation(amplitude, method='changepoint')
+activity = nk.emg_activation(emg_cleaned=emg_cleaned, sampling_rate=1000, method='pelt')
 ```
-- Detects abrupt transitions in signal properties
+- Detects abrupt transitions in signal properties (Pruned Exact Linear Time)
 - Identifies activation/deactivation points
-- Useful for complex temporal patterns
+- Needs the cleaned (or raw) EMG signal via `emg_cleaned=`, not the amplitude envelope
 
-**4. Bimodality (Silva et al., 2013):**
+**4. BioSPPy onset detection:**
 ```python
-activity = nk.emg_activation(amplitude, method='bimodal')
+activity = nk.emg_activation(emg_cleaned=emg_cleaned, sampling_rate=1000, method='biosppy')
 ```
-- Tests for bimodal distribution (active vs. rest)
-- Determines optimal separation threshold
-- Statistically principled
+- BioSPPy full-wave-rectification + threshold approach
+- Needs the cleaned EMG signal via `emg_cleaned=`, not the amplitude envelope
 
 **Key parameters:**
 - `duration_min`: Minimum activation duration (seconds)
@@ -313,7 +312,7 @@ amplitude = nk.emg_amplitude(cleaned, sampling_rate=1000)
 
 # 3. Detect activation periods
 activity, info = nk.emg_activation(amplitude, sampling_rate=1000,
-                                   method='threshold', threshold='auto')
+                                   method='threshold', threshold='default')
 
 # 4. Comprehensive processing (alternative)
 signals, info = nk.emg_process(emg_raw, sampling_rate=1000)

--- a/skills/neurokit2/references/eog.md
+++ b/skills/neurokit2/references/eog.md
@@ -27,9 +27,9 @@ signals, info = nk.eog_process(eog_signal, sampling_rate=500, method='neurokit')
 - `info`: Dictionary with blink indices and parameters
 
 **Methods:**
-- `'neurokit'`: NeuroKit2 optimized approach (default)
+- `'neurokit'`: NeuroKit2 optimized approach
 - `'agarwal2019'`: Agarwal et al. (2019) algorithm
-- `'mne'`: MNE-Python method
+- `'mne'`: MNE-Python method (default for blink detection; requires the `mne` package)
 - `'brainstorm'`: Brainstorm toolbox approach
 - `'kong1998'`: Kong et al. (1998) method
 
@@ -73,8 +73,8 @@ blinks, info = nk.eog_peaks(cleaned_eog, sampling_rate=500, method='neurokit',
 ```
 
 **Methods:**
-- `'neurokit'`: Amplitude and duration criteria (default)
-- `'mne'`: MNE-Python blink detection
+- `'mne'`: MNE-Python blink detection (default; requires the `mne` package)
+- `'neurokit'`: Amplitude and duration criteria
 - `'brainstorm'`: Brainstorm approach
 - `'blinker'`: BLINKER algorithm (Kleifges et al., 2017)
 
@@ -113,7 +113,7 @@ blinks_dict = nk.eog_findpeaks(cleaned_eog, sampling_rate=500, method='neurokit'
 Extract characteristics of individual blinks.
 
 ```python
-features = nk.eog_features(signals, sampling_rate=500)
+features = nk.eog_features(signals["EOG_Clean"], info["EOG_Blinks"], sampling_rate=500)
 ```
 
 **Computed features:**
@@ -285,7 +285,7 @@ cleaned = nk.eog_clean(eog_raw, sampling_rate=500, method='neurokit')
 blinks, info = nk.eog_peaks(cleaned, sampling_rate=500, method='neurokit')
 
 # 3. Extract features
-features = nk.eog_features(signals, sampling_rate=500)
+features = nk.eog_features(cleaned, info["EOG_Blinks"], sampling_rate=500)
 
 # 4. Comprehensive processing (alternative)
 signals, info = nk.eog_process(eog_raw, sampling_rate=500)

--- a/skills/neurokit2/references/hrv.md
+++ b/skills/neurokit2/references/hrv.md
@@ -326,12 +326,13 @@ Quantifies abnormal short-term fluctuations reflecting autonomic dysregulation.
 Respiratory Sinus Arrhythmia - heart rate modulation by breathing.
 
 ```python
-rsa = nk.hrv_rsa(peaks, rsp_signal, sampling_rate=1000, method='porges1980')
+rsa = nk.hrv_rsa(ecg_signals, rsp_signals, sampling_rate=1000)
 ```
 
-**Methods:**
-- `'porges1980'`: Porges-Bohrer method (band-pass filtered HR around breathing frequency)
-- `'harrison2021'`: Peak-to-trough RSA (max-min HR per breath cycle)
+**Returns** several RSA indices together (there is no method to select); among them:
+- Peak-to-trough (P2T): max-min HR per breath cycle
+- Porges-Bohrer: band-pass filtered HR around the breathing frequency
+- Gates and other variants
 
 **Requirements:**
 - Both ECG and respiratory signals
@@ -339,7 +340,7 @@ rsa = nk.hrv_rsa(peaks, rsp_signal, sampling_rate=1000, method='porges1980')
 - At least several breath cycles
 
 **Returns:**
-- `RSA`: RSA magnitude (beats/min or similar units depending on method)
+- A dict of RSA indices keyed by method (there is no plain `RSA` key): e.g. `RSA_P2T_Mean`, `RSA_P2T_SD`, `RSA_PorgesBohrer`, `RSA_Gates_Mean` (magnitudes in beats/min or similar units depending on method)
 
 ### hrv_rqa()
 
@@ -369,7 +370,7 @@ Preprocess RR-intervals before HRV analysis.
 
 ```python
 processed_intervals = nk.intervals_process(rr_intervals, interpolate=False,
-                                           interpolate_sampling_rate=1000)
+                                           interpolation_rate=100)
 ```
 
 **Operations:**

--- a/skills/neurokit2/references/ppg.md
+++ b/skills/neurokit2/references/ppg.md
@@ -29,8 +29,8 @@ signals, info = nk.ppg_process(ppg_signal, sampling_rate=100, method='elgendi')
 - `info`: Dictionary with peak indices and parameters
 
 **Methods:**
-- `'elgendi'`: Elgendi et al. (2013) algorithm (default, robust)
-- `'nabian2018'`: Nabian et al. (2018) approach
+- `method='elgendi'` (default) runs the full clean-and-peak pipeline end to end.
+- For other algorithms, run the stages separately: `ppg_clean` accepts `'elgendi'`, `'nabian2018'`, `'langevin2021'`, `'goda2024'`, `'none'`; `ppg_peaks` accepts `'elgendi'`, `'bishop'`, `'charlton'`, `'charlton2024'`. `ppg_process` forwards `method` to both stages, so `'elgendi'` is the only value valid for it directly.
 
 ## Preprocessing Functions
 
@@ -68,10 +68,9 @@ peaks, info = nk.ppg_peaks(cleaned_ppg, sampling_rate=100, method='elgendi',
 ```
 
 **Methods:**
-- `'elgendi'`: Two moving averages with dynamic thresholding
-- `'bishop'`: Bishop's algorithm
-- `'nabian2018'`: Nabian's approach
-- `'scipy'`: Simple scipy peak detection
+- `'elgendi'` (default): Two moving averages with dynamic thresholding
+- `'bishop'`: Bishop & Ercole (2018) algorithm
+- `'charlton'` / `'charlton2024'`: Charlton et al. peak detectors
 
 **Artifact correction:**
 - Set `correct_artifacts=True` for physiological plausibility checks
@@ -160,12 +159,12 @@ results = nk.ppg_intervalrelated(signals, sampling_rate=100)
 Assess signal quality and reliability.
 
 ```python
-quality = nk.ppg_quality(ppg_signal, sampling_rate=100, method='averageQRS')
+quality = nk.ppg_quality(ppg_signal, sampling_rate=100, method='templatematch')
 ```
 
 **Methods:**
 
-**1. averageQRS (default):**
+**1. templatematch (default):**
 - Template matching approach
 - Correlates each pulse with average template
 - Returns quality scores 0-1 per beat

--- a/skills/neurokit2/references/rsp.md
+++ b/skills/neurokit2/references/rsp.md
@@ -200,7 +200,7 @@ symmetry = nk.rsp_symmetry(cleaned_rsp, peaks)
 Respiratory Rate Variability - analogous to heart rate variability.
 
 ```python
-rrv_indices = nk.rsp_rrv(peaks, sampling_rate=100)
+rrv_indices = nk.rsp_rrv(signals, sampling_rate=100)  # signals: the DataFrame from rsp_process (has RSP_Rate)
 ```
 
 **Time-domain metrics:**
@@ -225,7 +225,7 @@ rrv_indices = nk.rsp_rrv(peaks, sampling_rate=100)
 Respiratory Volume per Time - fMRI confound regressor.
 
 ```python
-rvt = nk.rsp_rvt(cleaned_rsp, peaks, sampling_rate=100)
+rvt = nk.rsp_rvt(cleaned_rsp, sampling_rate=100)
 ```
 
 **Calculation:**
@@ -239,7 +239,7 @@ rvt = nk.rsp_rvt(cleaned_rsp, peaks, sampling_rate=100)
 - Respiratory confound regression
 
 **Reference:**
-- Birn, R. M., et al. (2008). Separating respiratory-variation-related fluctuations from neuronal-activity-related fluctuations in fMRI. NeuroImage, 31(4), 1536-1548.
+- Birn, R. M., et al. (2006). Separating respiratory-variation-related fluctuations from neuronal-activity-related fluctuations in fMRI. NeuroImage, 31(4), 1536-1548.
 
 ### rsp_rav()
 
@@ -443,7 +443,7 @@ ecg_signals, ecg_info = nk.ecg_process(ecg, sampling_rate=1000)
 rsp_signals, rsp_info = nk.rsp_process(rsp, sampling_rate=100)
 
 # Respiratory sinus arrhythmia (RSA)
-rsa = nk.hrv_rsa(ecg_info['ECG_R_Peaks'], rsp_signals['RSP_Clean'], sampling_rate=1000)
+rsa = nk.hrv_rsa(ecg_signals, rsp_signals, sampling_rate=1000)
 
 # Or use bio_process for multi-signal integration
 bio_signals, bio_info = nk.bio_process(ecg=ecg, rsp=rsp, sampling_rate=1000)
@@ -505,6 +505,6 @@ bio_signals, bio_info = nk.bio_process(ecg=ecg, rsp=rsp, sampling_rate=1000)
 
 ## References
 
-- Khodadad, D., Nordebo, S., Müller, B., Waldmann, A., Yerworth, R., Becher, T., ... & Bayford, R. (2018). A review of tissue substitutes for ultrasound imaging. Ultrasound in medicine & biology, 44(9), 1807-1823.
+- Khodadad, D., Nordebo, S., Müller, B., Waldmann, A., Yerworth, R., Becher, T., ... & Bayford, R. (2018). Optimized breath detection algorithm in electrical impedance tomography. Physiological Measurement, 39(9), 094001.
 - Grossman, P., & Taylor, E. W. (2007). Toward understanding respiratory sinus arrhythmia: Relations to cardiac vagal tone, evolution and biobehavioral functions. Biological psychology, 74(2), 263-285.
 - Birn, R. M., Diamond, J. B., Smith, M. A., & Bandettini, P. A. (2006). Separating respiratory-variation-related fluctuations from neuronal-activity-related fluctuations in fMRI. NeuroImage, 31(4), 1536-1548.

--- a/skills/neurokit2/references/signal_processing.md
+++ b/skills/neurokit2/references/signal_processing.md
@@ -12,7 +12,7 @@ Apply frequency-domain filtering to remove noise or isolate frequency bands.
 
 ```python
 filtered = nk.signal_filter(signal, sampling_rate=1000, lowcut=None, highcut=None,
-                            method='butterworth', order=5)
+                            method='butterworth', order=2)
 ```
 
 **Filter types (via lowcut/highcut combinations):**
@@ -60,10 +60,10 @@ notch = nk.signal_filter(signal, sampling_rate=1000, method='powerline', powerli
 
 ### signal_sanitize()
 
-Remove invalid values (NaN, inf) and optionally interpolate.
+Drop a Pandas Series' custom index, returning the values as a plain NumPy array (use after set_index). It does not remove NaN/inf; use `signal_fillmissing` or pandas `dropna` for that.
 
 ```python
-clean_signal = nk.signal_sanitize(signal, interpolate=True)
+clean_signal = nk.signal_sanitize(signal)
 ```
 
 **Use cases:**
@@ -142,6 +142,7 @@ components = nk.signal_decompose(signal, sampling_rate=1000, method='emd')
 - Data-adaptive decomposition into Intrinsic Mode Functions (IMFs)
 - Each IMF represents different frequency content (high to low)
 - No predefined basis functions
+- Requires the optional `EMD-signal` package (`uv pip install EMD-signal`); the `'ssa'` method below has no extra dependency
 
 **Singular Spectrum Analysis (SSA):**
 ```python
@@ -168,7 +169,7 @@ components = nk.signal_decompose(signal, method='ssa')
 Reconstruct signal from decomposed components.
 
 ```python
-reconstructed = nk.signal_recompose(components, indices=[1, 2, 3])
+reconstructed = nk.signal_recompose(components, method='wcorr', threshold=0.5)
 ```
 
 **Use case:**
@@ -185,10 +186,8 @@ binary = nk.signal_binarize(signal, method='threshold', threshold=0.5)
 ```
 
 **Methods:**
-- `'threshold'`: Simple threshold
-- `'median'`: Median-based
-- `'mean'`: Mean-based
-- `'quantile'`: Percentile-based
+- `'threshold'` (default): Values above `threshold` become 1 (default `threshold='auto'`, i.e. the signal mean)
+- `'mixture'`: Gaussian mixture model (two-class clustering into 0/1)
 
 **Use case:**
 - Event detection from continuous signal
@@ -251,20 +250,18 @@ merged = nk.signal_merge(signal1, signal2, time1=None, time2=None, sampling_rate
 Identify periods of constant signal (artifacts or sensor failure).
 
 ```python
-flatline_mask = nk.signal_flatline(signal, duration=5.0, sampling_rate=1000)
+flatline_pct = nk.signal_flatline(signal, threshold=0.01)
 ```
 
 **Returns:**
-- Binary mask where True indicates flatline periods
-- Duration threshold prevents false positives from normal stability
+- `float`: the proportion (0.0-1.0) of samples where the signal is flat (consecutive absolute difference < threshold)
 
 ### signal_noise()
 
-Add various types of noise to signal.
+Generate colored noise (it does not take an input signal; to add noise to a signal use `signal_distort`).
 
 ```python
-noisy = nk.signal_noise(signal, sampling_rate=1000, noise_type='gaussian',
-                        amplitude=0.1)
+noise = nk.signal_noise(duration=10, sampling_rate=1000, beta=1)  # beta: 0=white, 1=pink, 2=brown
 ```
 
 **Noise types:**
@@ -303,15 +300,15 @@ peaks_dict = nk.signal_findpeaks(signal, height_min=None, height_max=None,
 
 **Key parameters:**
 - `height_min/max`: Absolute amplitude thresholds
-- `relative_height_min/max`: Relative to signal range (0-1)
-- `threshold`: Minimum prominence
-- `distance`: Minimum samples between peaks
+- `relative_height_min/max`: Height thresholds relative to a baseline (in SD units)
+- `relative_mean` / `relative_median` / `relative_max`: Choose the baseline for the relative thresholds (mean is the default)
 
 **Returns:**
-- Dictionary with:
+- Dictionary with keys:
   - `'Peaks'`: Peak indices
-  - `'Height'`: Peak amplitudes
   - `'Distance'`: Inter-peak intervals
+  - `'Height'`: Peak amplitudes
+  - `'Width'`, `'Onsets'`, `'Offsets'`: Peak width and onset/offset indices
 
 **Use cases:**
 - Generic peak detection for any signal
@@ -364,37 +361,37 @@ rate = nk.signal_rate(peaks, sampling_rate=1000, desired_length=None)
 
 ### signal_period()
 
-Find dominant period/frequency in signal.
+Compute the instantaneous period (in seconds) from detected event locations (peaks).
 
 ```python
-period = nk.signal_period(signal, sampling_rate=1000, method='autocorrelation',
-                          show=False)
+period = nk.signal_period(peaks, sampling_rate=1000, desired_length=None,
+                          interpolation_method='monotone_cubic')
 ```
 
-**Methods:**
-- `'autocorrelation'`: Peak in autocorrelation function
-- `'powerspectraldensity'`: Peak in frequency spectrum
+**Parameters:**
+- `peaks`: Indices (or a boolean/marker array) of detected events, e.g. R-peaks from `ecg_peaks`
+- `desired_length`: If set, interpolate the period series to this length (e.g. the original signal length)
+- `interpolation_method`: Interpolation used between events (default `'monotone_cubic'`)
 
 **Returns:**
-- Period in samples or seconds
-- Frequency (1/period) in Hz
+- An array of the period (in seconds) between successive events, optionally interpolated to `desired_length`
 
 **Use case:**
-- Detect dominant rhythm
-- Estimate fundamental frequency
-- Breathing rate, heart rate estimation
+- Period (and, as its reciprocal, rate) from cardiac or respiratory peaks
+- Convert event series to a continuous instantaneous-period signal
 
 ### signal_phase()
 
 Compute instantaneous phase of signal.
 
 ```python
-phase = nk.signal_phase(signal, method='hilbert')
+phase = nk.signal_phase(signal, method='radians')
 ```
 
-**Methods:**
-- `'hilbert'`: Hilbert transform (analytic signal)
-- `'wavelet'`: Wavelet-based phase
+**Methods (output units):**
+- `'radians'`: Phase in radians (default)
+- `'degrees'`: Phase between 0 and 360
+- `'percents'`: Phase between 0 and 1
 
 **Returns:**
 - Phase in radians (-π to π) or 0 to 1 (normalized)
@@ -409,19 +406,18 @@ phase = nk.signal_phase(signal, method='hilbert')
 Compute Power Spectral Density.
 
 ```python
-psd, freqs = nk.signal_psd(signal, sampling_rate=1000, method='welch',
-                           max_frequency=None, show=False)
+psd_df = nk.signal_psd(signal, sampling_rate=1000, method='welch', show=False)
+# psd_df is a DataFrame with columns "Frequency" and "Power"
 ```
 
 **Methods:**
 - `'welch'`: Welch's periodogram (windowed FFT, default)
-- `'multitapers'`: Multitaper method (superior spectral estimation)
-- `'lomb'`: Lomb-Scargle (unevenly sampled data)
+- `'multitapers'`: Multitaper method (superior spectral estimation; requires the optional `mne` package)
+- `'lomb'`: Lomb-Scargle (unevenly sampled data; requires the optional `astropy` package)
 - `'burg'`: Autoregressive (parametric)
 
 **Returns:**
-- `psd`: Power at each frequency (units²/Hz)
-- `freqs`: Frequency bins (Hz)
+- A DataFrame with columns `Frequency` (Hz) and `Power` (units²/Hz)
 
 **Use case:**
 - Frequency content analysis
@@ -433,11 +429,7 @@ psd, freqs = nk.signal_psd(signal, sampling_rate=1000, method='welch',
 Compute power in specific frequency bands.
 
 ```python
-power_dict = nk.signal_power(signal, sampling_rate=1000, frequency_bands={
-    'VLF': (0.003, 0.04),
-    'LF': (0.04, 0.15),
-    'HF': (0.15, 0.4)
-}, method='welch')
+power_df = nk.signal_power(signal, frequency_band=[(0.003, 0.04), (0.04, 0.15), (0.15, 0.4)], sampling_rate=1000)
 ```
 
 **Returns:**
@@ -454,7 +446,7 @@ power_dict = nk.signal_power(signal, sampling_rate=1000, frequency_bands={
 Compute autocorrelation function.
 
 ```python
-autocorr = nk.signal_autocor(signal, lag=1000, show=False)
+autocorr, info = nk.signal_autocor(signal, lag=1000, show=False)
 ```
 
 **Interpretation:**
@@ -488,12 +480,11 @@ n_crossings = nk.signal_zerocrossings(signal)
 Detect abrupt changes in signal properties (mean, variance).
 
 ```python
-changepoints = nk.signal_changepoints(signal, penalty=10, method='pelt', show=False)
+changepoints = nk.signal_changepoints(signal, change='meanvar', penalty=10, show=False)
 ```
 
-**Methods:**
-- `'pelt'`: Pruned Exact Linear Time (fast, exact)
-- `'binseg'`: Binary segmentation (faster, approximate)
+**Parameter:**
+- `change='meanvar'` (default): detect changes in the signal's mean and variance
 
 **Parameters:**
 - `penalty`: Controls sensitivity (higher = fewer changepoints)
@@ -516,10 +507,8 @@ sync = nk.signal_synchrony(signal1, signal2, method='correlation')
 ```
 
 **Methods:**
-- `'correlation'`: Pearson correlation
-- `'coherence'`: Frequency-domain coherence
-- `'mutual_information'`: Information-theoretic measure
-- `'phase'`: Phase locking value
+- `'hilbert'` (default): instantaneous phase synchrony via the Hilbert transform
+- `'correlation'`: rolling-window Pearson correlation
 
 **Use cases:**
 - Heart-brain coupling
@@ -631,7 +620,7 @@ nk.signal_plot(signal, sampling_rate=1000, peaks=None, show=True)
 **Combining operations:**
 ```python
 # Typical preprocessing pipeline
-signal = nk.signal_sanitize(raw_signal)  # Remove invalid values
+signal = nk.signal_sanitize(raw_signal)  # reset to default integer index
 signal = nk.signal_filter(signal, sampling_rate=1000, lowcut=0.5, highcut=40)  # Bandpass
 signal = nk.signal_detrend(signal, method='polynomial', order=1)  # Remove linear trend
 ```


### PR DESCRIPTION
Many examples used wrong signatures, mis-unpacked return values, or named methods and columns that do not exist, so they crash or silently bind the wrong object.

- the complexity functions return `(value, info)` tuples; unpack both values.
- correct signatures: `signal_psd` (returns a DataFrame), `rsp_rvt`, `hrv_rsa`, `emg_activation`, `signal_period`, `fractal_mfdfa`.
- correct method and return names: the `ppg_peaks` vs `ppg_process` method sets, `microstates_segment` keys, the `bio_analyze` RSA columns.
- correct several documented defaults, for example `eeg_badchannels`.

Checked on neurokit2 0.2.13 with simulated signals.
