### PR TITLE
literature-review: fix script crashes, dedup, year filtering, and DOI parsing

### DIFF
--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: literature-review
-description: Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).
-allowed-tools: Read Write Edit Bash
+description: 'Conduct comprehensive, systematic literature reviews across multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). Use for systematic reviews, meta-analyses, scoping reviews, research synthesis, and broad literature searches, including topic overviews, surveys, and state-of-the-art summaries that gather and organize the major work on a subject by theme or method. Produces professionally formatted markdown and PDF documents with verified citations in multiple styles (APA, Nature, Vancouver, etc.).'
+allowed-tools: Read, Write, Edit, Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.
@@ -13,7 +13,12 @@ metadata:
 
 Conduct systematic, comprehensive literature reviews following rigorous academic methodology. Search multiple literature databases, synthesize findings thematically, verify all citations for accuracy, and generate professional output documents in markdown and PDF formats.
 
-This skill uses the **parallel-web skill** (`parallel-cli search`) as the primary web search tool for broad academic literature discovery, supplemented by specialized database access skills (gget, bioservices, datacommons-client). It provides specialized tools for citation verification, result aggregation, and document generation.
+This skill is **runnable standalone** using the built-in `WebSearch` and `WebFetch` tools plus direct calls to free academic database APIs (NCBI E-utilities, the bioRxiv/medRxiv API, arXiv, Semantic Scholar, CrossRef, OpenAlex). It provides bundled tools for citation verification, result aggregation, and document generation that depend only on Python `requests` and pandoc.
+
+Several **optional external skills/tools** can enhance the workflow if you have them installed, but none are bundled with this skill and none are required:
+- **parallel-cli** (`parallel-web-tools` on PyPI), an optional external CLI for broad web search and URL extraction with academic domain filtering.
+- **scientific-schematics**, an optional external skill for AI-generated diagrams (see the bundled `scripts/generate_schematic*.py` for a self-contained alternative that uses a paid OpenRouter key).
+- Domain-specific data skills/libraries (e.g. `gget`, `bioservices`, `datacommons-client`, `scanpy`, `anndata`, `biopython`), optional external tools for specialized biomedical/structural databases. Where they are mentioned below, a direct-API fallback is given so the core workflow never depends on them.
 
 ## When to Use This Skill
 
@@ -28,23 +33,23 @@ Use this skill when:
 
 ## Visual Enhancement with Scientific Schematics
 
-**⚠️ MANDATORY: Every literature review MUST include at least 1-2 AI-generated figures using the scientific-schematics skill.**
-
-This is not optional. Literature reviews without visual elements are incomplete. Before finalizing any document:
+**Recommended (optional): Include 1-2 figures so the review communicates visually.** Figures strengthen a review but are not required for it to be valid; a text-only review with a well-described PRISMA flow is still complete. When you do add figures:
 1. Generate at minimum ONE schematic or diagram (e.g., PRISMA flow diagram for systematic reviews)
 2. Prefer 2-3 figures for comprehensive reviews (search strategy flowchart, thematic synthesis diagram, conceptual framework)
 
 **How to generate figures:**
-- Use the **scientific-schematics** skill to generate AI-powered publication-quality diagrams
-- Simply describe your desired diagram in natural language
-- Nano Banana Pro will automatically generate, review, and refine the schematic
+- **scientific-schematics** is an optional external skill (not bundled with this skill); use it if you have it installed for AI-powered publication-quality diagrams.
+- Alternatively, use the bundled scripts below, which are self-contained but call a paid third-party API.
+- For a no-cost, no-dependency option, hand-author a PRISMA box diagram directly in markdown/ASCII (see the PRISMA section under Phase 3) or with any local drawing tool.
 
-**How to generate schematics:**
+**How to generate schematics (bundled scripts, optional, paid API):**
 ```bash
 python scripts/generate_schematic.py "your diagram description" -o figures/output.png
 ```
 
-The AI will automatically:
+> **Paid-API disclosure:** `scripts/generate_schematic.py` and `scripts/generate_schematic_ai.py` call the **OpenRouter** API and require a paid `OPENROUTER_API_KEY` (set as an environment variable or in a `.env` file). They send your prompt to OpenRouter and incur per-image charges; they make outbound network requests on every run. The image model is `google/gemini-3.1-flash-image-preview` (marketed as "Nano Banana 2"); review uses `google/gemini-3.5-flash`. These scripts are entirely optional and are not needed for any other phase of the workflow.
+
+The script will automatically:
 - Create publication-quality images with proper formatting
 - Review and refine through multiple iterations
 - Ensure accessibility (colorblind-friendly, high contrast)
@@ -59,7 +64,7 @@ The AI will automatically:
 - Conceptual framework illustrations
 - Any complex concept that benefits from visualization
 
-For detailed guidance on creating schematics, refer to the scientific-schematics skill documentation.
+For detailed guidance on creating schematics, refer to the scientific-schematics skill documentation if that optional skill is installed; otherwise use the bundled scripts (paid API) or hand-author the diagram.
 
 ---
 
@@ -82,7 +87,7 @@ Literature reviews follow a structured, multi-phase workflow:
    - List synonyms, abbreviations, and related terms for each concept
    - Plan Boolean operators (AND, OR, NOT) to combine terms
    - Select minimum 3 complementary databases
-   - **Use the parallel-web skill (`parallel-cli search`) for initial scoping** to quickly gauge the landscape before formal database searches
+   - **For initial scoping**, use the built-in `WebSearch` tool to quickly gauge the landscape before formal database searches (or the optional external `parallel-cli search` if installed)
 
 4. **Set Inclusion/Exclusion Criteria**:
    - Date range (e.g., last 10 years: 2015-2024)
@@ -95,43 +100,31 @@ Literature reviews follow a structured, multi-phase workflow:
 
 1. **Multi-Database Search**:
 
-   Select databases appropriate for the domain. **Always start with parallel-web for broad academic coverage**, then supplement with domain-specific databases.
+   Select databases appropriate for the domain. **The default, no-dependency path is the built-in `WebSearch` tool for broad scholarly coverage plus direct calls to free database APIs.** If you have the optional external `parallel-cli` installed, you can use it instead for the broad-coverage step; it is not required.
 
-   **Web-Based Academic Search (parallel-web skill — START HERE):**
-   - Use `parallel-cli search` with academic domain filtering for broad scholarly coverage
-   - Run two searches: academic-focused + general to catch all relevant sources
-   ```bash
-   # Academic-focused search across scholarly sources
-   parallel-cli search "your research topic" -q "keyword1" -q "keyword2" \
-     --json --max-results 10 --excerpt-max-chars-total 27000 \
-     --include-domains "scholar.google.com,arxiv.org,pubmed.ncbi.nlm.nih.gov,semanticscholar.org,biorxiv.org,medrxiv.org,ncbi.nlm.nih.gov,nature.com,science.org,ieee.org,acm.org,springer.com,wiley.com,cell.com,pnas.org,nih.gov" \
-     -o sources/litreview_<topic>-academic.json
+   **Web-Based Academic Search (default, built-in `WebSearch`):**
+   - Run two `WebSearch` queries to catch all relevant sources: one academic-focused (append scholarly domains/terms such as `arxiv.org`, `pubmed`, `nature.com`, `semanticscholar.org`, `biorxiv.org` to the query) and one general.
+   - Use the built-in `WebFetch` tool to pull full content from specific paper URLs or PDFs found in the results (e.g. `WebFetch "https://arxiv.org/abs/XXXX.XXXXX"`).
+   - Save the distilled results into `sources/` so the search stays reproducible.
 
-   # General search for supplementary sources
-   parallel-cli search "your research topic" -q "keyword1" -q "keyword2" \
-     --json --max-results 10 --excerpt-max-chars-total 27000 \
-     -o sources/litreview_<topic>-general.json
-   ```
-   - Use `parallel-cli extract` to fetch full content from specific paper URLs or PDFs found in search results
-   ```bash
-   parallel-cli extract "https://arxiv.org/abs/XXXX.XXXXX" --json
-   ```
+   **Optional external alternative (`parallel-cli`, not bundled):** if installed, `parallel-cli search ... --include-domains "..."` and `parallel-cli extract "<url>" --json` provide the same broad-search and extraction steps with academic domain filtering. Install with `uv tool install "parallel-web-tools[cli]"`.
 
-   **Biomedical & Life Sciences:**
-   - Use `gget` skill: `gget search pubmed "search terms"` for PubMed/PMC
-   - Use `gget` skill: `gget search biorxiv "search terms"` for preprints
-   - Use `bioservices` skill for ChEMBL, KEGG, UniProt, etc.
+   **Biomedical & Life Sciences (direct APIs, no extra skill required):**
+   - **PubMed/PMC:** use NCBI E-utilities directly via `WebFetch`. Search with ESearch (`https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=<query>&retmax=100`) to get PMIDs, then fetch records with ESummary/EFetch (`.../esummary.fcgi?db=pubmed&id=<pmids>`). `gget search` does NOT query PubMed (it searches Ensembl genes and requires `-s/--species`), so do not use it here.
+   - **bioRxiv/medRxiv preprints:** use the bioRxiv API directly, e.g. `WebFetch "https://api.biorxiv.org/details/biorxiv/<YYYY-MM-DD>/<YYYY-MM-DD>"` (swap `biorxiv` for `medrxiv`), or search via the web UI / `WebSearch` restricted to `biorxiv.org`/`medrxiv.org`. `gget` has no PubMed or bioRxiv module.
+   - **ChEMBL, KEGG, UniProt, etc.:** query their public REST APIs via `WebFetch`. The optional external `bioservices` library wraps these if you have it installed.
 
    **General Scientific Literature:**
-   - Search arXiv via direct API (preprints in physics, math, CS, q-bio)
-   - Search Semantic Scholar via API (200M+ papers, cross-disciplinary)
-   - Use Google Scholar for comprehensive coverage (manual or careful scraping)
+   - Search arXiv via its direct API (`http://export.arxiv.org/api/query?search_query=...`), preprints in physics, math, CS, q-bio
+   - Search Semantic Scholar via its public API (200M+ papers, cross-disciplinary; see rate limits in `references/database_strategies.md`)
+   - Search OpenAlex via its free API (`https://api.openalex.org/works?search=...`, no key required) for broad cross-disciplinary coverage and citation metadata
+   - Use Google Scholar for comprehensive coverage (manual search; no official API)
 
    **Specialized Databases:**
-   - Use `gget alphafold` for protein structures
-   - Use `gget cosmic` for cancer genomics
-   - Use `datacommons-client` for demographic/statistical data
-   - Use specialized databases as appropriate for the domain
+   - AlphaFold protein structures: AlphaFold DB API (`https://alphafold.ebi.ac.uk/api/...`); the optional external `gget alphafold` wraps it
+   - Cancer genomics (COSMIC): the COSMIC website/downloads; the optional external `gget cosmic` wraps it
+   - Demographic/statistical data: the Data Commons REST API; the optional external `datacommons-client` wraps it
+   - Use other specialized databases via their public APIs as appropriate for the domain
 
 2. **Document Search Parameters**:
    ```markdown
@@ -156,7 +149,7 @@ Literature reviews follow a structured, multi-phase workflow:
    - Combine all results into a single file
    - Use `scripts/search_databases.py` for post-processing:
      ```bash
-     python search_databases.py combined_results.json \
+     python scripts/search_databases.py combined_results.json \
        --deduplicate \
        --format markdown \
        --output aggregated_results.md
@@ -166,7 +159,7 @@ Literature reviews follow a structured, multi-phase workflow:
 
 1. **Deduplication**:
    ```bash
-   python search_databases.py results.json --deduplicate --output unique_results.json
+   python scripts/search_databases.py results.json --deduplicate --output unique_results.json
    ```
    - Removes duplicates by DOI (primary) or title (fallback)
    - Document number of duplicates removed
@@ -187,14 +180,35 @@ Literature reviews follow a structured, multi-phase workflow:
    - Document specific reasons for exclusion
    - Record final number of included studies
 
-5. **Create PRISMA Flow Diagram**:
+5. **Create PRISMA 2020 Flow Diagram**:
+
+   Follow the PRISMA 2020 flow-diagram box sequence. Track *records* (database hits/citations) and *reports* (retrievable full-text documents) separately, account for everything removed *before* screening, and give explicit exclusion reason counts at full-text assessment. (The bundled `assets/review_template.md` follows this same structure.)
    ```
-   Initial search: n = X
-   ├─ After deduplication: n = Y
-   ├─ After title screening: n = Z
-   ├─ After abstract screening: n = A
-   └─ Included in review: n = B
+   Identification
+     Records identified from databases/registers: n = X
+       (per source, e.g. PubMed n=…, bioRxiv n=…)
+     Records removed before screening:
+       - Duplicate records removed:                n = …
+       - Records marked ineligible by automation:  n = …
+       - Records removed for other reasons:         n = …
+
+   Screening
+     Records screened (title/abstract):            n = …
+       Records excluded:                           n = …
+     Reports sought for retrieval:                 n = …
+       Reports not retrieved:                      n = …
+     Reports assessed for eligibility:             n = …
+       Reports excluded (with reason + count):
+         - Wrong population:                        n = …
+         - Wrong intervention/outcome:              n = …
+         - Wrong study design:                      n = …
+         - Other (specify):                         n = …
+
+   Included
+     Studies included in review:                   n = …
+     Reports of included studies:                  n = …
    ```
+   Every full-text exclusion MUST be recorded with a specific reason and its count (list excluded reports in Appendix C of the template).
 
 ### Phase 4: Data Extraction and Quality Assessment
 
@@ -206,12 +220,13 @@ Literature reviews follow a structured, multi-phase workflow:
    - Limitations noted by authors
    - Funding sources and conflicts of interest
 
-2. **Assess Study Quality**:
-   - **For RCTs**: Use Cochrane Risk of Bias tool
-   - **For observational studies**: Use Newcastle-Ottawa Scale
-   - **For systematic reviews**: Use AMSTAR 2
-   - Rate each study: High, Moderate, Low, or Very Low quality
-   - Consider excluding very low-quality studies
+2. **Assess Risk of Bias (per study)** using the tool-specific labels of each instrument, do NOT relabel these as GRADE certainty levels:
+   - **For RCTs**: Cochrane RoB 2 → rate each study **Low risk / Some concerns / High risk**
+   - **For non-randomized/observational studies**: ROBINS-I (**Low / Moderate / Serious / Critical**) or the Newcastle-Ottawa Scale (star score)
+   - **For systematic reviews**: AMSTAR 2 (**High / Moderate / Low / Critically low** confidence in the review)
+   - Consider excluding studies at high/critical risk of bias, or analyze them separately in a sensitivity analysis
+
+   **Rate certainty of evidence (per outcome), separately, with GRADE**: each outcome (not each study) is rated **High / Moderate / Low / Very Low** certainty, downgraded for risk of bias, inconsistency, indirectness, imprecision, and publication bias. Risk of bias is one *input* to GRADE; it is not the same scale.
 
 3. **Organize by Themes**:
    - Identify 3-5 major themes across studies
@@ -322,14 +337,14 @@ Literature reviews follow a structured, multi-phase workflow:
 
 ### PubMed / PubMed Central
 
-Access via `gget` skill:
+Access via NCBI E-utilities (Entrez), using the built-in `WebFetch` tool. Do NOT use `gget search` here: it queries Ensembl genes (and requires `-s/--species`); it has no PubMed module.
 ```bash
-# Search PubMed
-gget search pubmed "CRISPR gene editing" -l 100
-
-# Search with filters
-# Use PubMed Advanced Search Builder to construct complex queries
-# Then execute via gget or direct Entrez API
+# 1. ESearch -> list of PMIDs for a query
+#   https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=CRISPR+gene+editing&retmax=100
+# 2. ESummary/EFetch -> records for those PMIDs
+#   https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=<pmid1,pmid2,...>
+# Build complex queries with the PubMed Advanced Search Builder, then run the
+# resulting term string through ESearch.
 ```
 
 **Search tips**:
@@ -341,9 +356,12 @@ gget search pubmed "CRISPR gene editing" -l 100
 
 ### bioRxiv / medRxiv
 
-Access via `gget` skill:
+Access via the bioRxiv/medRxiv API (using `WebFetch`) or `WebSearch` restricted to the preprint domains. `gget` has no bioRxiv module.
 ```bash
-gget search biorxiv "CRISPR sickle cell" -l 50
+# bioRxiv content API (swap "biorxiv" for "medrxiv"); filter the returned
+# records by your search terms client-side:
+#   https://api.biorxiv.org/details/biorxiv/2015-01-01/2024-12-31
+# Or: WebSearch "CRISPR sickle cell site:biorxiv.org"
 ```
 
 **Important considerations**:
@@ -369,7 +387,7 @@ search_query = "cat:q-bio.QM AND ti:\"single cell sequencing\""
 
 ### Semantic Scholar
 
-Access via direct API (requires API key, or use free tier):
+Access via the public API (an API key is optional, not required; see rate limits in `references/database_strategies.md`):
 - 200M+ papers across all fields
 - Excellent for cross-disciplinary searches
 - Provides citation graphs and paper recommendations
@@ -377,37 +395,27 @@ Access via direct API (requires API key, or use free tier):
 
 ### Specialized Biomedical Databases
 
-Use appropriate skills:
-- **ChEMBL**: `bioservices` skill for chemical bioactivity
-- **UniProt**: `gget` or `bioservices` skill for protein information
-- **KEGG**: `bioservices` skill for pathways and genes
-- **COSMIC**: `gget` skill for cancer mutations
-- **AlphaFold**: `gget alphafold` for protein structures
-- **PDB**: `gget` or direct API for experimental structures
+Query the free public REST API of each database directly with `WebFetch`. The named libraries are **optional external wrappers** (not bundled, not required):
+- **ChEMBL**: ChEMBL REST API (optional wrapper: `bioservices`) for chemical bioactivity
+- **UniProt**: UniProt REST API (optional wrappers: `gget`, `bioservices`) for protein information
+- **KEGG**: KEGG REST API (optional wrapper: `bioservices`) for pathways and genes
+- **COSMIC**: COSMIC website/downloads (optional wrapper: `gget`) for cancer mutations
+- **AlphaFold**: AlphaFold DB API (optional wrapper: `gget alphafold`) for protein structures
+- **PDB**: RCSB PDB REST API (optional wrapper: `gget`) for experimental structures
 
 ### Citation Chaining
 
 Expand search via citation networks:
 
 1. **Forward citations** (papers citing key papers):
-   - Use `parallel-cli search` to find papers citing a specific work:
-     ```bash
-     parallel-cli search "papers citing [Author et al. Year] [paper title]" \
-       -q "citing" -q "[key author]" \
-       --json --max-results 10 --excerpt-max-chars-total 27000 \
-       --include-domains "scholar.google.com,semanticscholar.org,arxiv.org,pubmed.ncbi.nlm.nih.gov" \
-       -o sources/litreview_forward_citations.json
-     ```
+   - Use the **Semantic Scholar or OpenAlex APIs** (via `WebFetch`) to list papers that cite a given DOI, both expose a citations endpoint and require no key (OpenAlex: `https://api.openalex.org/works?filter=cites:<openalex-id>`)
+   - Use the built-in `WebSearch` tool (e.g. `WebSearch "papers citing [Author et al. Year] [title]" site:semanticscholar.org`), or the optional external `parallel-cli search --include-domains "..."` if installed
    - Use Google Scholar "Cited by"
-   - Use Semantic Scholar or OpenAlex APIs
    - Identifies newer research building on seminal work
 
 2. **Backward citations** (references from key papers):
-   - Use `parallel-cli extract` to fetch full text of key papers and extract their reference lists:
-     ```bash
-     parallel-cli extract "https://doi.org/10.xxxx/yyyy" --json
-     ```
-   - Extract references from included papers
+   - Use the built-in `WebFetch` tool to pull the full text of key papers and extract their reference lists (or the optional external `parallel-cli extract "<url>" --json` if installed)
+   - Better yet, read references straight from the CrossRef/OpenAlex record for the DOI (both list cited works)
    - Identify highly cited foundational work
    - Find papers cited by multiple included studies
 
@@ -474,19 +482,13 @@ For any topic, identify foundational work by:
 ## Best Practices
 
 ### Search Strategy
-1. **Start with parallel-web**: Use `parallel-cli search` with academic domains for initial broad coverage before querying specialized databases
-2. **Use multiple databases** (minimum 3): Ensures comprehensive coverage — parallel-web counts as one source
+1. **Start broad with `WebSearch`**: Use the built-in `WebSearch` tool (or the optional external `parallel-cli search`) with academic domains for initial broad coverage before querying specialized databases
+2. **Use multiple databases** (minimum 3): Ensures comprehensive coverage, the broad web search counts as one source
 3. **Include preprint servers**: Captures latest unpublished findings
-4. **Document everything**: Search strings, dates, result counts for reproducibility — save all parallel-cli output to `sources/`
+4. **Document everything**: Search strings, dates, result counts for reproducibility, save all search output to `sources/`
 5. **Test and refine**: Run pilot searches, review results, adjust search terms
 6. **Sort by citations**: When available, sort search results by citation count to surface influential work first
-7. **Use parallel-cli extract**: Fetch full content from promising URLs found during search to verify relevance before full-text screening
-
-### Screening and Selection
-1. **Use multiple databases** (minimum 3): Ensures comprehensive coverage
-2. **Include preprint servers**: Captures latest unpublished findings
-3. **Document everything**: Search strings, dates, result counts for reproducibility
-4. **Test and refine**: Run pilot searches, review results, adjust search terms
+7. **Fetch full content with `WebFetch`**: Pull full text from promising URLs found during search (or the optional external `parallel-cli extract`) to verify relevance before full-text screening
 
 ### Screening and Selection
 1. **Use clear criteria**: Document inclusion/exclusion criteria before screening
@@ -533,24 +535,27 @@ Complete workflow for a biomedical literature review:
 # 1. Create review document from template
 cp assets/review_template.md crispr_sickle_cell_review.md
 
-# 2. Start with parallel-web for broad academic search
-parallel-cli search "CRISPR Cas9 sickle cell disease gene therapy efficacy" \
-  -q "CRISPR" -q "sickle cell" -q "gene therapy" \
-  --json --max-results 10 --excerpt-max-chars-total 27000 \
-  --include-domains "scholar.google.com,arxiv.org,pubmed.ncbi.nlm.nih.gov,semanticscholar.org,biorxiv.org,nature.com,science.org,cell.com,pnas.org,nih.gov" \
-  -o sources/litreview_crispr_scd-academic.json
+# 2. Start with a broad academic search using the built-in WebSearch tool
+#    Run one academic-focused query and one general query, e.g.:
+#      WebSearch "CRISPR Cas9 sickle cell disease gene therapy efficacy
+#                 (arxiv.org OR pubmed OR semanticscholar.org OR biorxiv.org OR nature.com)"
+#      WebSearch "CRISPR sickle cell disease clinical trials treatment"
+#    Save the distilled hits to sources/ for reproducibility.
+#
+#    Optional external alternative (parallel-cli, if installed):
+#      parallel-cli search "CRISPR Cas9 sickle cell disease gene therapy efficacy" \
+#        -q "CRISPR" -q "sickle cell" -q "gene therapy" \
+#        --json --max-results 10 --excerpt-max-chars-total 27000 \
+#        --include-domains "arxiv.org,pubmed.ncbi.nlm.nih.gov,semanticscholar.org,biorxiv.org,nature.com,cell.com,pnas.org" \
+#        -o sources/litreview_crispr_scd-academic.json
 
-parallel-cli search "CRISPR sickle cell disease clinical trials treatment" \
-  -q "CRISPR" -q "sickle cell" \
-  --json --max-results 10 --excerpt-max-chars-total 27000 \
-  -o sources/litreview_crispr_scd-general.json
+# 3. Search specialized databases via their public APIs (WebFetch)
+# - PubMed: NCBI E-utilities (esearch.fcgi / efetch.fcgi) -- NOT gget
+# - bioRxiv/medRxiv: api.biorxiv.org -- NOT gget
+# - arXiv: export.arxiv.org/api/query ; Semantic Scholar / OpenAlex: public APIs
+# - Export results in JSON format into sources/
 
-# 3. Search specialized databases using appropriate skills
-# - Use gget skill for PubMed, bioRxiv
-# - Use direct API access for arXiv, Semantic Scholar
-# - Export results in JSON format
-
-# 4. Aggregate and process results (combine parallel-cli + database results)
+# 4. Aggregate and process results (combine web-search + database results)
 python scripts/search_databases.py combined_results.json \
   --deduplicate \
   --rank citations \
@@ -561,7 +566,7 @@ python scripts/search_databases.py combined_results.json \
   --summary
 
 # 5. Screen results and extract data
-# - Use parallel-cli extract to fetch full content from promising URLs
+# - Use the WebFetch tool (or optional parallel-cli extract) to fetch full content from promising URLs
 # - Manually screen titles, abstracts, full texts
 # - Extract key data into the review document
 # - Organize by themes
@@ -594,21 +599,24 @@ python scripts/generate_pdf.py crispr_sickle_cell_review.md \
 
 This skill works seamlessly with other scientific skills:
 
-### Web Search & Extraction (parallel-web skill — PRIMARY)
-- **parallel-cli search**: Broad academic and general web search with domain filtering — use for initial scoping, finding papers, citation chaining, and supplementary searches
-- **parallel-cli extract**: Fetch full content from paper URLs, journal websites, and preprint servers — use for reading abstracts, extracting reference lists, and verifying paper details
+All of the tools listed below are **optional external dependencies**: none ship with this skill, and the core workflow runs without them using the built-in `WebSearch`/`WebFetch` tools and direct database APIs.
+
+### Web Search & Extraction (optional external `parallel-cli`)
+`parallel-cli` is a real, separately installed CLI (`parallel-web-tools` on PyPI), not a bundled skill. If installed, it can replace the built-in `WebSearch`/`WebFetch` steps:
+- **parallel-cli search**: Broad academic and general web search with domain filtering, initial scoping, finding papers, citation chaining, supplementary searches
+- **parallel-cli extract**: Fetch full content from paper URLs, journal websites, and preprint servers, reading abstracts, extracting reference lists, verifying paper details
 - **parallel-cli search --include-domains**: Academic-focused search across scholarly domains (arxiv.org, pubmed, nature.com, etc.)
 
-### Database Access Skills
-- **gget**: PubMed, bioRxiv, COSMIC, AlphaFold, Ensembl, UniProt
+### Database Access (optional external wrappers; use the public APIs directly otherwise)
+- **gget**: COSMIC, AlphaFold, Ensembl, UniProt (NOTE: `gget` does NOT cover PubMed or bioRxiv, use NCBI E-utilities and the bioRxiv API directly for those)
 - **bioservices**: ChEMBL, KEGG, Reactome, UniProt, PubChem
 - **datacommons-client**: Demographics, economics, health statistics
 
-### Analysis Skills
-- **pydeseq2**: RNA-seq differential expression (for methods sections)
-- **scanpy**: Single-cell analysis (for methods sections)
-- **anndata**: Single-cell data (for methods sections)
-- **biopython**: Sequence analysis (for background sections)
+### Analysis Libraries (optional external; for methods/background sections only)
+- **pydeseq2**: RNA-seq differential expression
+- **scanpy**: Single-cell analysis
+- **anndata**: Single-cell data
+- **biopython**: Sequence analysis
 
 ### Visualization Skills
 - **matplotlib**: Generate figures and plots for review
@@ -653,9 +661,10 @@ This skill works seamlessly with other scientific skills:
 
 ## Dependencies
 
-### Required CLI Tools
+### Optional External CLI Tools
 ```bash
-# parallel-cli (PRIMARY — for web search and URL extraction)
+# parallel-cli (OPTIONAL, external; the workflow runs without it using the
+# built-in WebSearch/WebFetch tools). Real package: parallel-web-tools on PyPI.
 curl -fsSL https://parallel.ai/install.sh | bash
 # Or: uv tool install "parallel-web-tools[cli]"
 # Authenticate: parallel-cli auth
@@ -663,8 +672,10 @@ curl -fsSL https://parallel.ai/install.sh | bash
 
 ### Required Python Packages
 ```bash
-pip install requests  # For citation verification
+pip install requests  # For citation verification (the only required dependency for the bundled scripts)
 ```
+
+> Image-generation scripts (`scripts/generate_schematic*.py`) are optional and additionally require a paid `OPENROUTER_API_KEY`; see the Visual Enhancement section.
 
 ### Required System Tools
 ```bash
@@ -687,8 +698,8 @@ python scripts/generate_pdf.py --check-deps
 This literature-review skill provides:
 
 1. **Systematic methodology** following academic best practices
-2. **Parallel-web powered search** using `parallel-cli search` for fast, broad academic literature discovery with scholarly domain filtering
-3. **Multi-database integration** via existing scientific skills (gget, bioservices, datacommons-client)
+2. **Built-in web search** using the `WebSearch`/`WebFetch` tools for fast, broad academic literature discovery (optionally the external `parallel-cli`)
+3. **Multi-database integration** via direct public APIs (NCBI E-utilities, bioRxiv, arXiv, Semantic Scholar, OpenAlex, CrossRef), with optional external wrappers (gget, bioservices, datacommons-client)
 4. **Citation verification** ensuring accuracy and credibility
 5. **Professional output** in markdown and PDF formats
 6. **Comprehensive guidance** covering the entire review process

--- a/skills/literature-review/references/citation_styles.md
+++ b/skills/literature-review/references/citation_styles.md
@@ -2,13 +2,15 @@
 
 This document provides detailed guidelines for formatting citations in various academic styles commonly used in literature reviews.
 
+> **Note:** All author names, titles, and DOIs in the examples below (e.g. `10.1038/nrd.2023.001`, `10.1101/2024.01.001`) are fictional and shown for illustration of formatting only. They do not resolve to real works; always verify real DOIs with `verify_citations.py`.
+
 ## APA Style (7th Edition)
 
 ### Journal Articles
 
 **Format**: Author, A. A., Author, B. B., & Author, C. C. (Year). Title of article. *Title of Periodical*, *volume*(issue), page range. https://doi.org/xx.xxx/yyyy
 
-**Example**: Smith, J. D., Johnson, M. L., & Williams, K. R. (2023). Machine learning approaches in drug discovery. *Nature Reviews Drug Discovery*, *22*(4), 301-318. https://doi.org/10.1038/nrd.2023.001
+**Example** (illustrative; DOI is not real): Smith, J. D., Johnson, M. L., & Williams, K. R. (2023). Machine learning approaches in drug discovery. *Nature Reviews Drug Discovery*, *22*(4), 301-318. https://doi.org/10.1038/nrd.2023.001
 
 ### Books
 

--- a/skills/literature-review/references/database_strategies.md
+++ b/skills/literature-review/references/database_strategies.md
@@ -7,14 +7,14 @@ This document provides comprehensive guidance for searching multiple literature 
 ### Biomedical & Life Sciences
 
 #### PubMed / PubMed Central
-- **Access**: Use `gget` skill or WebFetch tool
+- **Access**: NCBI E-utilities directly via the `WebFetch` tool, ESearch (`esearch.fcgi?db=pubmed&term=<query>`) for PMIDs, then ESummary/EFetch for records. (Note: `gget search` queries Ensembl genes and requires `-s/--species`; it has no PubMed module, so do not use it for PubMed.)
 - **Coverage**: 35M+ citations in biomedical literature
 - **Best for**: Clinical studies, biomedical research, genetics, molecular biology
 - **Search tips**: Use MeSH terms, Boolean operators (AND, OR, NOT), field tags [Title], [Author]
 - **Example**: `"CRISPR"[Title] AND "gene editing"[Title/Abstract] AND 2020:2024[Publication Date]`
 
 #### bioRxiv / medRxiv
-- **Access**: Use `gget` skill or direct API
+- **Access**: The bioRxiv/medRxiv API directly via `WebFetch` (`https://api.biorxiv.org/details/biorxiv/<from-date>/<to-date>`; swap `biorxiv` for `medrxiv`), or `WebSearch` restricted to `biorxiv.org`/`medrxiv.org`. (`gget` has no bioRxiv module.)
 - **Coverage**: Preprints in biology and medicine
 - **Best for**: Latest unpublished research, cutting-edge findings
 - **Note**: Not peer-reviewed; verify findings with caution
@@ -30,11 +30,11 @@ This document provides comprehensive guidance for searching multiple literature 
 - **Search format**: `cat:q-bio.QM AND title:"single cell"`
 
 #### Semantic Scholar
-- **Access**: Direct API (requires API key)
+- **Access**: Direct API (an API key is optional, not required)
 - **Coverage**: 200M+ papers across all fields
 - **Best for**: Cross-disciplinary searches, citation graphs, paper recommendations
 - **Features**: Influential citations, paper summaries, related papers
-- **Rate limits**: 100 requests/5 minutes with API key
+- **Rate limits**: Unauthenticated requests share a throttled public pool (roughly 1000 requests/second shared across all anonymous users, so effective throughput is low and bursty). An introductory API key grants a dedicated allowance on the order of ~1 request/second. Confirm current limits in the official docs: https://api.semanticscholar.org/api-docs/
 
 #### Google Scholar
 - **Access**: Web scraping (use cautiously) or manual search
@@ -45,36 +45,38 @@ This document provides comprehensive guidance for searching multiple literature 
 
 ### Specialized Databases
 
+> Each database below has a free public REST API reachable directly with the built-in `WebFetch` tool. The named libraries (`gget`, `bioservices`) are **optional external wrappers**, not bundled with this skill and not required.
+
 #### ChEMBL / PubChem
-- **Access**: Use `gget` skill or `bioservices` skill
+- **Access**: ChEMBL REST API / PubChem PUG REST directly via `WebFetch` (optional external wrappers: `gget`, `bioservices`)
 - **Coverage**: Chemical compounds, bioactivity data, drug molecules
 - **Best for**: Drug discovery, chemical biology, medicinal chemistry
 - **ChEMBL**: 2M+ compounds, bioactivity data
 - **PubChem**: 110M+ compounds, assay data
 
 #### UniProt
-- **Access**: Use `gget` skill or `bioservices` skill
+- **Access**: UniProt REST API directly via `WebFetch` (optional external wrappers: `gget`, `bioservices`)
 - **Coverage**: Protein sequence and functional information
 - **Best for**: Protein research, sequence analysis, functional annotations
 - **Search by**: Protein name, gene name, organism, function
 
 #### KEGG (Kyoto Encyclopedia of Genes and Genomes)
-- **Access**: Use `bioservices` skill
+- **Access**: KEGG REST API directly via `WebFetch` (optional external wrapper: `bioservices`)
 - **Coverage**: Pathways, diseases, drugs, genes
 - **Best for**: Pathway analysis, systems biology, metabolic research
 
 #### COSMIC (Catalogue of Somatic Mutations in Cancer)
-- **Access**: Use `gget` skill or direct download
+- **Access**: COSMIC website/downloads directly (optional external wrapper: `gget`)
 - **Coverage**: Cancer genomics, somatic mutations
 - **Best for**: Cancer research, mutation analysis
 
 #### AlphaFold Database
-- **Access**: Use `gget` skill with `alphafold` command
+- **Access**: AlphaFold DB API (`https://alphafold.ebi.ac.uk/api/...`) directly via `WebFetch` (optional external wrapper: `gget alphafold`)
 - **Coverage**: 200M+ protein structure predictions
 - **Best for**: Structural biology, protein modeling
 
 #### PDB (Protein Data Bank)
-- **Access**: Use `gget` or direct API
+- **Access**: RCSB PDB REST API directly via `WebFetch` (optional external wrapper: `gget`)
 - **Coverage**: Experimental 3D structures of proteins, nucleic acids
 - **Best for**: Structural biology, drug design, molecular modeling
 
@@ -196,12 +198,12 @@ Search at least 3 complementary databases:
 4. Document reasons for exclusion at each stage
 
 ### Phase 5: Quality Assessment
-1. Assess study quality using appropriate tools:
-   - **RCTs**: Cochrane Risk of Bias tool
-   - **Observational**: Newcastle-Ottawa Scale
-   - **Systematic reviews**: AMSTAR 2
-2. Grade quality of evidence (high, moderate, low, very low)
-3. Consider excluding very low-quality studies
+1. Assess **risk of bias per study** using the tool's own labels (these are NOT GRADE levels):
+   - **RCTs**: Cochrane RoB 2 → Low risk / Some concerns / High risk
+   - **Observational**: ROBINS-I (Low / Moderate / Serious / Critical) or Newcastle-Ottawa (star score)
+   - **Systematic reviews**: AMSTAR 2 (High / Moderate / Low / Critically low confidence)
+2. Rate **certainty of evidence per outcome** with GRADE (High / Moderate / Low / Very Low), downgrading for risk of bias, inconsistency, indirectness, imprecision, and publication bias. Risk of bias is one input to GRADE, not the same scale.
+3. Consider excluding studies at high/critical risk of bias, or examine them in a sensitivity analysis
 
 ---
 
@@ -412,29 +414,31 @@ Many databases suggest related articles:
 ## Example Multi-Database Search Workflow
 
 ```python
-# Example workflow using available skills
+# Example workflow using built-in tools and direct database APIs
 
-# 1. Search PubMed via gget
+# 1. Search PubMed via NCBI E-utilities (WebFetch), NOT gget
 search_term = "CRISPR AND sickle cell disease"
-# Use gget search pubmed search_term
+# ESearch for PMIDs:
+#   https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=<search_term>&retmax=100
+# Then ESummary/EFetch for records by PMID
 
-# 2. Search bioRxiv
-# Use gget search biorxiv search_term
+# 2. Search bioRxiv via its API (WebFetch)
+#   https://api.biorxiv.org/details/biorxiv/<from-date>/<to-date>   (filter by search_term)
 
-# 3. Search arXiv for computational papers
-# Search arXiv with: cat:q-bio AND "CRISPR" AND "sickle cell"
+# 3. Search arXiv for computational papers via its API
+#   http://export.arxiv.org/api/query?search_query=cat:q-bio AND all:"CRISPR sickle cell"
 
-# 4. Search Semantic Scholar via API
-# Use semantic scholar API with search query
+# 4. Search Semantic Scholar via its public API
+# Use the Semantic Scholar API with the search query
 
 # 5. Aggregate and deduplicate results
-# python search_databases.py combined_results.json --deduplicate --format markdown --output review_papers.md
+# python scripts/search_databases.py combined_results.json --deduplicate --format markdown --output review_papers.md
 
 # 6. Verify all citations
-# python verify_citations.py review_papers.md
+# python scripts/verify_citations.py review_papers.md
 
 # 7. Generate final PDF
-# python generate_pdf.py review_papers.md --citation-style nature
+# python scripts/generate_pdf.py review_papers.md --citation-style nature
 ```
 
 ---

--- a/skills/literature-review/scripts/generate_pdf.py
+++ b/skills/literature-review/scripts/generate_pdf.py
@@ -71,14 +71,38 @@ def generate_pdf(
     if number_sections:
         cmd.append('--number-sections')
 
-    # Add citation processing if bibliography exists
+    # Add citation processing if bibliography exists.
+    # NOTE: citation_style is only applied when a sibling "<markdown>.bib"
+    # bibliography is present; with no .bib, pandoc has nothing to format and
+    # the style is silently a no-op. Warn so the user is not surprised.
     bib_file = Path(markdown_file).with_suffix('.bib')
     if bib_file.exists():
-        cmd.extend([
-            '--citeproc',
-            '--bibliography', str(bib_file),
-            '--csl', f'{citation_style}.csl' if not citation_style.endswith('.csl') else citation_style
-        ])
+        # The CSL value is a bare filename (e.g. "apa.csl"); no CSL files are
+        # bundled with this skill, so pandoc resolves it relative to the working
+        # directory (or its data dir). The user must supply the matching .csl
+        # file. Download styles from https://github.com/citation-style-language/styles
+        csl = citation_style if citation_style.endswith('.csl') else f'{citation_style}.csl'
+        if not os.path.exists(csl):
+            print(f"Warning: CSL style file '{csl}' not found in the working directory.")
+            print("  No CSL files are bundled. Provide the .csl yourself (e.g. from")
+            print("  https://github.com/citation-style-language/styles); falling back")
+            print("  to pandoc's default citation style.")
+            # Omit --csl entirely: passing a missing file makes pandoc fail,
+            # whereas with no --csl pandoc uses its built-in default style.
+            cmd.extend([
+                '--citeproc',
+                '--bibliography', str(bib_file),
+            ])
+        else:
+            cmd.extend([
+                '--citeproc',
+                '--bibliography', str(bib_file),
+                '--csl', csl
+            ])
+    elif citation_style != 'apa':
+        # A non-default citation style was requested but cannot take effect.
+        print(f"Warning: --citation-style '{citation_style}' was requested, but no "
+              f"bibliography file '{bib_file}' exists; the style will be ignored.")
 
     # Add custom template if provided
     if template and os.path.exists(template):
@@ -130,7 +154,9 @@ def main():
     if len(sys.argv) < 2:
         print("Usage: python generate_pdf.py <markdown_file> [output_pdf] [--citation-style STYLE]")
         print("\nOptions:")
-        print("  --citation-style STYLE    Citation style (default: apa)")
+        print("  --output FILE             Output PDF path (alternative to the positional argument)")
+        print("  --citation-style STYLE    Citation style (default: apa). Only applied when a")
+        print("                            sibling <markdown_file>.bib bibliography exists.")
         print("  --no-toc                  Disable table of contents")
         print("  --no-numbers              Disable section numbering")
         print("  --check-deps              Check if dependencies are installed")
@@ -150,6 +176,13 @@ def main():
     number_sections = True
 
     # Parse optional flags
+    # --output is an alias for the positional output argument; the explicit
+    # flag wins if both are supplied.
+    if '--output' in sys.argv:
+        idx = sys.argv.index('--output')
+        if idx + 1 < len(sys.argv):
+            output_pdf = sys.argv[idx + 1]
+
     if '--citation-style' in sys.argv:
         idx = sys.argv.index('--citation-style')
         if idx + 1 < len(sys.argv):

--- a/skills/literature-review/scripts/generate_schematic.py
+++ b/skills/literature-review/scripts/generate_schematic.py
@@ -6,7 +6,7 @@ Generate any scientific diagram by describing it in natural language.
 Nano Banana 2 handles everything automatically with smart iterative refinement.
 
 Smart iteration: Only regenerates if quality is below threshold for your document type.
-Quality review: Uses Gemini 3.1 Pro Preview for professional scientific evaluation.
+Quality review: Uses Gemini 3.5 Flash for professional scientific evaluation.
 
 Usage:
     # Generate for journal paper (highest quality threshold)
@@ -36,7 +36,7 @@ How it works:
   Simply describe your diagram in natural language
   Nano Banana 2 generates it automatically with:
   - Smart iteration (only regenerates if quality is below threshold)
-  - Quality review by Gemini 3.1 Pro Preview
+  - Quality review by Gemini 3.5 Flash
   - Document-type aware quality thresholds
   - Publication-ready output
 

--- a/skills/literature-review/scripts/generate_schematic_ai.py
+++ b/skills/literature-review/scripts/generate_schematic_ai.py
@@ -4,7 +4,7 @@ AI-powered scientific schematic generation using Nano Banana 2.
 
 This script uses a smart iterative refinement approach:
 1. Generate initial image with Nano Banana 2
-2. AI quality review using Gemini 3.1 Pro Preview for scientific critique
+2. AI quality review using Gemini 3.5 Flash for scientific critique
 3. Only regenerate if quality is below threshold for document type
 4. Repeat until quality meets standards (max iterations)
 
@@ -52,7 +52,7 @@ def _load_env_file():
 class ScientificSchematicGenerator:
     """Generate scientific schematics using AI with smart iterative refinement.
     
-    Uses Gemini 3.1 Pro Preview for quality review to determine if regeneration is needed.
+    Uses Gemini 3.5 Flash for quality review to determine if regeneration is needed.
     Multiple passes only occur if the generated schematic doesn't meet the
     quality threshold for the target document type.
     """
@@ -145,10 +145,10 @@ IMPORTANT - NO FIGURE NUMBERS:
         self._last_error = None  # Track last error for better reporting
         self.base_url = "https://openrouter.ai/api/v1"
         # Nano Banana 2 - Google's advanced image generation model
-        # https://openrouter.ai/google/gemini-3-pro-image-preview
+        # https://openrouter.ai/google/gemini-3.1-flash-image-preview
         self.image_model = "google/gemini-3.1-flash-image-preview"
-        # Gemini 3.1 Pro Preview for quality review - excellent vision and reasoning
-        self.review_model = "google/gemini-3.1-pro-preview"
+        # Gemini 3.5 Flash for quality review - excellent vision and reasoning
+        self.review_model = "google/gemini-3.5-flash"
         
     def _log(self, message: str):
         """Log message if verbose mode is enabled."""
@@ -400,9 +400,9 @@ IMPORTANT - NO FIGURE NUMBERS:
                     iteration: int, doc_type: str = "default",
                     max_iterations: int = 2) -> Tuple[str, float, bool]:
         """
-        Review generated image using Gemini 3.1 Pro Preview for quality analysis.
+        Review generated image using Gemini 3.5 Flash for quality analysis.
         
-        Uses Gemini 3.1 Pro Preview's superior vision and reasoning capabilities to
+        Uses Gemini 3.5 Flash's superior vision and reasoning capabilities to
         evaluate the schematic quality and determine if regeneration is needed.
         
         Args:
@@ -415,7 +415,7 @@ IMPORTANT - NO FIGURE NUMBERS:
         Returns:
             Tuple of (critique text, quality score 0-10, needs_improvement bool)
         """
-        # Use Gemini 3.1 Pro Preview for review - excellent vision and analysis
+        # Use Gemini 3.5 Flash for review - excellent vision and analysis
         image_data_url = self._image_to_base64(image_path)
         
         # Get quality threshold for this document type
@@ -491,7 +491,7 @@ If score < {threshold}, mark as NEEDS_IMPROVEMENT with specific suggestions."""
         ]
         
         try:
-            # Use Gemini 3.1 Pro Preview for high-quality review
+            # Use Gemini 3.5 Flash for high-quality review
             response = self._make_request(
                 model=self.review_model,
                 messages=messages
@@ -500,7 +500,7 @@ If score < {threshold}, mark as NEEDS_IMPROVEMENT with specific suggestions."""
             # Extract text response
             choices = response.get("choices", [])
             if not choices:
-                return "Image generated successfully", 8.0
+                return "Image generated successfully", 8.0, False
             
             message = choices[0].get("message", {})
             content = message.get("content", "")
@@ -656,8 +656,8 @@ Generate a publication-quality scientific diagram that meets all the guidelines 
                 f.write(image_data)
             print(f"✓ Saved: {iter_path}")
             
-            # Review image using Gemini 3.1 Pro Preview
-            print(f"Reviewing image with Gemini 3.1 Pro Preview...")
+            # Review image using Gemini 3.5 Flash
+            print(f"Reviewing image with Gemini 3.5 Flash...")
             critique, score, needs_improvement = self.review_image(
                 str(iter_path), user_prompt, i, doc_type, iterations
             )

--- a/skills/literature-review/scripts/search_databases.py
+++ b/skills/literature-review/scripts/search_databases.py
@@ -91,26 +91,37 @@ def deduplicate_results(results: List[Dict]) -> List[Dict]:
         Deduplicated list
     """
     seen_dois = set()
-    seen_titles = set()
+    seen_title_sigs = set()
     unique_results = []
 
     for result in results:
-        doi = result.get('doi', '').lower().strip()
-        title = result.get('title', '').lower().strip()
+        # Guard against None values (a record may carry doi=None or title=None)
+        doi = (result.get('doi') or '').lower().strip()
+        # Normalize title (collapse whitespace) so minor formatting differences
+        # across databases still collapse a genuine duplicate.
+        title = ' '.join((result.get('title') or '').lower().split())
+        year = str(result.get('year') or '').strip()
+        # Guard the title match by year: the same title in the same year is
+        # almost certainly the same work (e.g. a preprint and the published
+        # article under different DOIs), whereas an identical title in a
+        # different year is likely a distinct work and must NOT be merged.
+        title_sig = (title, year) if title else None
 
-        # Check DOI first (more reliable)
+        # DOI is authoritative: a previously seen DOI is always a duplicate.
         if doi and doi in seen_dois:
             continue
-
-        # Check title as fallback
-        if not doi and title in seen_titles:
+        # Fall back to the year-guarded title signature ONLY when this record has
+        # no usable DOI of its own, so a shared title alone never overrides
+        # DOI-distinct records. Two records with different DOIs are distinct works
+        # (e.g. an erratum or a same-title paper in two venues) and must be kept,
+        # even if their title+year happens to match.
+        if not doi and title_sig and title_sig in seen_title_sigs:
             continue
 
-        # Add to results
         if doi:
             seen_dois.add(doi)
-        if title:
-            seen_titles.add(title)
+        if title_sig:
+            seen_title_sigs.add(title_sig)
 
         unique_results.append(result)
 
@@ -127,10 +138,24 @@ def rank_results(results: List[Dict], criteria: str = 'citations') -> List[Dict]
     Returns:
         Ranked list
     """
+    def _as_int(value, default: int = 0) -> int:
+        """Coerce a possibly-string value to int, falling back on default.
+
+        Citation counts often arrive as strings; sorting them lexicographically
+        would rank '2' above '10'. Coerce to numeric first.
+        """
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return default
+
     if criteria == 'citations':
-        return sorted(results, key=lambda x: x.get('citations', 0), reverse=True)
+        return sorted(results, key=lambda x: _as_int(x.get('citations', 0)), reverse=True)
     elif criteria == 'year':
-        return sorted(results, key=lambda x: x.get('year', '0'), reverse=True)
+        # Years may arrive as ints (e.g. PubMed) or strings (e.g. JSON exports)
+        # across aggregated sources; coerce so mixed types sort numerically
+        # instead of raising TypeError when comparing int to str.
+        return sorted(results, key=lambda x: _as_int(x.get('year', 0)), reverse=True)
     elif criteria == 'relevance':
         return sorted(results, key=lambda x: x.get('relevance_score', 0), reverse=True)
     else:
@@ -151,8 +176,18 @@ def filter_by_year(results: List[Dict], start_year: int = None, end_year: int = 
     filtered = []
 
     for result in results:
+        raw_year = result.get('year')
+        # Treat an absent, null, or empty year the same way as an unparseable
+        # one: include the record. Without this, a missing 'year' key would
+        # default to 0 and be silently dropped by any start_year bound, while a
+        # present 'year': null would parse-fail and be kept (inconsistent), and
+        # preprints / incomplete metadata that legitimately lack a year would be
+        # removed whenever a bound is set.
+        if raw_year is None or (isinstance(raw_year, str) and not raw_year.strip()):
+            filtered.append(result)
+            continue
         try:
-            year = int(result.get('year', 0))
+            year = int(raw_year)
             if start_year and year < start_year:
                 continue
             if end_year and year > end_year:

--- a/skills/literature-review/scripts/verify_citations.py
+++ b/skills/literature-review/scripts/verify_citations.py
@@ -7,6 +7,7 @@ Verifies DOIs, URLs, and citation metadata for accuracy.
 import re
 import requests
 import json
+from pathlib import Path
 from typing import Dict, List, Tuple
 from urllib.parse import urlparse
 import time
@@ -20,8 +21,29 @@ class CitationVerifier:
 
     def extract_dois(self, text: str) -> List[str]:
         """Extract all DOIs from text."""
-        doi_pattern = r'10\.\d{4,}/[^\s\]\)"]+'
-        return re.findall(doi_pattern, text)
+        # Allow ')' inside the match so legacy parenthesized (SICI-style) DOIs
+        # such as 10.1002/(SICI)1097-0258(...)... are captured whole instead of
+        # being truncated at the first ')'.
+        doi_pattern = r'10\.\d{4,}/[^\s\]"]+'
+        return [self._strip_doi_tail(doi) for doi in re.findall(doi_pattern, text)]
+
+    @staticmethod
+    def _strip_doi_tail(doi: str) -> str:
+        """Strip terminal punctuation a sentence or list can append to a DOI.
+
+        Removes a trailing period, comma, or semicolon (never part of a DOI). A
+        trailing ')' is stripped only when it is unbalanced (more ')' than '('
+        in the token), i.e. a DOI wrapped in prose like "(10.x/y)"; a ')' that
+        is balanced by an earlier '(' is structural (SICI DOIs) and kept.
+        """
+        while doi and doi[-1] in '.,;)':
+            if doi[-1] == ')':
+                if doi.count('(') >= doi.count(')'):
+                    break
+                doi = doi[:-1]
+            else:
+                doi = doi[:-1]
+        return doi
 
     def verify_doi(self, doi: str) -> Tuple[bool, Dict]:
         """
@@ -51,12 +73,18 @@ class CitationVerifier:
                 data = response.json()
                 message = data.get('message', {})
 
-                # Extract key metadata
+                # Extract key metadata. CrossRef can return a present-but-empty
+                # list for title / container-title (e.g. datasets, some books);
+                # a bare [0] would raise IndexError, so take the first element
+                # only when one exists and fall back to '' otherwise.
+                def _first(seq) -> str:
+                    return seq[0] if isinstance(seq, list) and seq else ''
+
                 metadata = {
-                    'title': message.get('title', [''])[0],
+                    'title': _first(message.get('title', [])),
                     'authors': self._format_authors(message.get('author', [])),
                     'year': self._extract_year(message),
-                    'journal': message.get('container-title', [''])[0],
+                    'journal': _first(message.get('container-title', [])),
                     'volume': message.get('volume', ''),
                     'pages': message.get('page', ''),
                     'doi': doi
@@ -84,13 +112,16 @@ class CitationVerifier:
         return ", ".join(formatted)
 
     def _extract_year(self, message: Dict) -> str:
-        """Extract publication year."""
-        date_parts = message.get('published-print', {}).get('date-parts', [[]])
-        if not date_parts or not date_parts[0]:
-            date_parts = message.get('published-online', {}).get('date-parts', [[]])
+        """Extract publication year.
 
-        if date_parts and date_parts[0]:
-            return str(date_parts[0][0])
+        CrossRef's canonical publication date is ``issued``; ``published`` is a
+        newer unified field, and ``published-print`` / ``published-online`` are
+        format-specific. Fall back through them in order of preference.
+        """
+        for field in ('issued', 'published', 'published-print', 'published-online'):
+            date_parts = message.get(field, {}).get('date-parts', [[]])
+            if date_parts and date_parts[0] and date_parts[0][0] is not None:
+                return str(date_parts[0][0])
         return ""
 
     def verify_url(self, url: str) -> Tuple[bool, int]:
@@ -211,8 +242,12 @@ def main():
             citation = verifier.format_citation_apa(metadata)
             print(f"\n{citation}")
 
-    # Save detailed report
-    output_file = filepath.replace('.md', '_citation_report.json')
+    # Save detailed report. Derive the report path from the input's stem so it
+    # is always a distinct sibling file; a naive str.replace('.md', ...) is a
+    # no-op (and would overwrite the source) for any non-.md or differently
+    # cased input, and mangles names that contain '.md' more than once.
+    src = Path(filepath)
+    output_file = str(src.with_name(f"{src.stem}_citation_report.json"))
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(report, f, indent=2)
 


### PR DESCRIPTION
A few script paths crashed or quietly did the wrong thing.

- `search_databases.py --rank year`: coerce mixed int/str years before sorting (it raised `TypeError`).
- dedup: keep records with distinct DOIs that happen to share a title and year.
- year filter: treat missing, None, and empty year the same way.
- `verify_citations.py`: build the report filename safely so a non-`.md` source is never overwritten, and survive an empty CrossRef title.
- DOI regex: pull legacy parenthesised (SICI) DOIs out whole.

Exercised on local fixtures, no network calls.
